### PR TITLE
feat(domain): task-5 — PRD 부록 B 기반 공통 타입과 에러 매핑 모듈 도입

### DIFF
--- a/packages/domain/src/api/errors.test.ts
+++ b/packages/domain/src/api/errors.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  type DomainError,
+  type DomainErrorCode,
+  DOMAIN_ERROR_CODES,
+  isDomainError,
+  toErrorResponse,
+} from './errors.js';
+
+describe('DomainError — PRD 부록 B 에러 코드', () => {
+  const expected: ReadonlyArray<DomainErrorCode> = [
+    'SLOT_CLOSED',
+    'PROMPT_MISMATCH',
+    'CLOCK_SKEW',
+    'RAW_EXPIRED',
+    'RETRY_COOLDOWN',
+    'RETRY_EXHAUSTED',
+    'INVITE_INVALID',
+    'INVITE_RATE_LIMITED',
+    'UNAUTHORIZED',
+    'FORBIDDEN',
+    'NOT_FOUND',
+    'VALIDATION_FAILED',
+  ];
+
+  it('exposes exactly the codes enumerated in PRD 부록 B + 공통 에러', () => {
+    expect([...DOMAIN_ERROR_CODES].sort()).toEqual([...expected].sort());
+  });
+
+  it('freezes the codes tuple so it cannot be mutated at runtime', () => {
+    expect(Object.isFrozen(DOMAIN_ERROR_CODES)).toBe(true);
+  });
+});
+
+describe('isDomainError', () => {
+  it('returns true for a properly shaped error', () => {
+    const e: DomainError = { code: 'SLOT_CLOSED', promptId: 'abc' };
+    expect(isDomainError(e)).toBe(true);
+  });
+
+  it('returns false for unknown shape', () => {
+    expect(isDomainError(null)).toBe(false);
+    expect(isDomainError(undefined)).toBe(false);
+    expect(isDomainError({})).toBe(false);
+    expect(isDomainError({ code: 'not-a-real-code' })).toBe(false);
+    expect(isDomainError('string')).toBe(false);
+    expect(isDomainError({ code: 123 })).toBe(false);
+  });
+});
+
+describe('toErrorResponse', () => {
+  it('maps each code to the correct HTTP status per PRD 부록 B', () => {
+    const cases: ReadonlyArray<[DomainError, number]> = [
+      [{ code: 'SLOT_CLOSED', promptId: 'p' }, 409],
+      [{ code: 'PROMPT_MISMATCH', expected: 'a', actual: 'b' }, 409],
+      [{ code: 'CLOCK_SKEW', serverTime: '2026-04-24T12:00:05Z' }, 422],
+      [{ code: 'RAW_EXPIRED', promptId: 'p' }, 410],
+      [{ code: 'RETRY_COOLDOWN', retryAfterSec: 300 }, 429],
+      [{ code: 'RETRY_EXHAUSTED' }, 429],
+      [{ code: 'INVITE_INVALID' }, 404],
+      [{ code: 'INVITE_RATE_LIMITED', retryAfterSec: 900 }, 429],
+      [{ code: 'UNAUTHORIZED' }, 401],
+      [{ code: 'FORBIDDEN' }, 403],
+      [{ code: 'NOT_FOUND', resource: 'group' }, 404],
+      [{ code: 'VALIDATION_FAILED', details: { fields: ['name'] } }, 400],
+    ];
+    for (const [err, status] of cases) {
+      expect(toErrorResponse(err).status).toBe(status);
+    }
+  });
+
+  it('produces a body containing the code and a Korean message', () => {
+    const { body } = toErrorResponse({ code: 'SLOT_CLOSED', promptId: 'p' });
+    expect(body.error).toBe('SLOT_CLOSED');
+    expect(typeof body.message).toBe('string');
+    expect(body.message.length).toBeGreaterThan(0);
+  });
+
+  it('includes retryAfterSec in RETRY_COOLDOWN details', () => {
+    const { body } = toErrorResponse({ code: 'RETRY_COOLDOWN', retryAfterSec: 300 });
+    expect(body.details).toMatchObject({ retryAfterSec: 300 });
+  });
+
+  it('includes retryAfterSec in INVITE_RATE_LIMITED details', () => {
+    const { body } = toErrorResponse({ code: 'INVITE_RATE_LIMITED', retryAfterSec: 900 });
+    expect(body.details).toMatchObject({ retryAfterSec: 900 });
+  });
+
+  it('includes serverTime for CLOCK_SKEW', () => {
+    const { body } = toErrorResponse({
+      code: 'CLOCK_SKEW',
+      serverTime: '2026-04-24T12:00:05Z',
+    });
+    expect(body.details).toMatchObject({ serverTime: '2026-04-24T12:00:05Z' });
+  });
+
+  it('passes through VALIDATION_FAILED details verbatim', () => {
+    const { body } = toErrorResponse({
+      code: 'VALIDATION_FAILED',
+      details: { fields: ['name', 'timezone'] },
+    });
+    expect(body.details).toMatchObject({ fields: ['name', 'timezone'] });
+  });
+});

--- a/packages/domain/src/api/errors.ts
+++ b/packages/domain/src/api/errors.ts
@@ -1,0 +1,115 @@
+import { assertNever } from '../shared/assert-never.js';
+
+export const DOMAIN_ERROR_CODES = Object.freeze([
+  'SLOT_CLOSED',
+  'PROMPT_MISMATCH',
+  'CLOCK_SKEW',
+  'RAW_EXPIRED',
+  'RETRY_COOLDOWN',
+  'RETRY_EXHAUSTED',
+  'INVITE_INVALID',
+  'INVITE_RATE_LIMITED',
+  'UNAUTHORIZED',
+  'FORBIDDEN',
+  'NOT_FOUND',
+  'VALIDATION_FAILED',
+] as const);
+
+export type DomainErrorCode = (typeof DOMAIN_ERROR_CODES)[number];
+
+export type DomainError =
+  | { readonly code: 'SLOT_CLOSED'; readonly promptId: string }
+  | { readonly code: 'PROMPT_MISMATCH'; readonly expected: string; readonly actual: string }
+  | { readonly code: 'CLOCK_SKEW'; readonly serverTime: string }
+  | { readonly code: 'RAW_EXPIRED'; readonly promptId: string }
+  | { readonly code: 'RETRY_COOLDOWN'; readonly retryAfterSec: number }
+  | { readonly code: 'RETRY_EXHAUSTED' }
+  | { readonly code: 'INVITE_INVALID' }
+  | { readonly code: 'INVITE_RATE_LIMITED'; readonly retryAfterSec: number }
+  | { readonly code: 'UNAUTHORIZED' }
+  | { readonly code: 'FORBIDDEN' }
+  | { readonly code: 'NOT_FOUND'; readonly resource: string }
+  | {
+      readonly code: 'VALIDATION_FAILED';
+      readonly details: { readonly [field: string]: unknown };
+    };
+
+export interface ErrorResponseBody {
+  readonly error: DomainErrorCode;
+  readonly message: string;
+  readonly details: Readonly<Record<string, unknown>>;
+}
+
+export interface ErrorResponse {
+  readonly status: number;
+  readonly body: ErrorResponseBody;
+}
+
+const DOMAIN_ERROR_CODE_SET: ReadonlySet<string> = new Set(DOMAIN_ERROR_CODES);
+
+export const isDomainError = (value: unknown): value is DomainError => {
+  if (value === null || typeof value !== 'object') return false;
+  const candidate = value as { code?: unknown };
+  return typeof candidate.code === 'string' && DOMAIN_ERROR_CODE_SET.has(candidate.code);
+};
+
+const MESSAGES: Readonly<Record<DomainErrorCode, string>> = {
+  SLOT_CLOSED: '해당 슬롯은 이미 마감되었습니다',
+  PROMPT_MISMATCH: '촬영 시작 시각과 슬롯이 일치하지 않습니다',
+  CLOCK_SKEW: '기기 시간이 서버와 어긋나 있습니다',
+  RAW_EXPIRED: '원본이 삭제되어 재시도할 수 없습니다',
+  RETRY_COOLDOWN: '잠시 후 다시 시도해주세요',
+  RETRY_EXHAUSTED: '재시도 한도를 초과했습니다',
+  INVITE_INVALID: '유효하지 않은 초대 코드입니다',
+  INVITE_RATE_LIMITED: '초대 시도 제한에 걸렸습니다',
+  UNAUTHORIZED: '로그인이 필요합니다',
+  FORBIDDEN: '접근 권한이 없습니다',
+  NOT_FOUND: '요청한 리소스를 찾을 수 없습니다',
+  VALIDATION_FAILED: '요청 형식이 올바르지 않습니다',
+};
+
+export const toErrorResponse = (error: DomainError): ErrorResponse => {
+  const message = MESSAGES[error.code];
+  switch (error.code) {
+    case 'SLOT_CLOSED':
+      return mk(409, error.code, message, { promptId: error.promptId });
+    case 'PROMPT_MISMATCH':
+      return mk(409, error.code, message, {
+        expected: error.expected,
+        actual: error.actual,
+      });
+    case 'CLOCK_SKEW':
+      return mk(422, error.code, message, { serverTime: error.serverTime });
+    case 'RAW_EXPIRED':
+      return mk(410, error.code, message, { promptId: error.promptId });
+    case 'RETRY_COOLDOWN':
+      return mk(429, error.code, message, { retryAfterSec: error.retryAfterSec });
+    case 'RETRY_EXHAUSTED':
+      return mk(429, error.code, message, {});
+    case 'INVITE_INVALID':
+      return mk(404, error.code, message, {});
+    case 'INVITE_RATE_LIMITED':
+      return mk(429, error.code, message, { retryAfterSec: error.retryAfterSec });
+    case 'UNAUTHORIZED':
+      return mk(401, error.code, message, {});
+    case 'FORBIDDEN':
+      return mk(403, error.code, message, {});
+    case 'NOT_FOUND':
+      return mk(404, error.code, message, { resource: error.resource });
+    case 'VALIDATION_FAILED':
+      return mk(400, error.code, message, { ...error.details });
+    /* istanbul ignore next -- exhaustiveness guard, unreachable by types */
+    default:
+      return assertNever(error);
+  }
+};
+
+const mk = (
+  status: number,
+  code: DomainErrorCode,
+  message: string,
+  details: Readonly<Record<string, unknown>>,
+): ErrorResponse => ({
+  status,
+  body: { error: code, message, details },
+});

--- a/packages/domain/src/api/index.ts
+++ b/packages/domain/src/api/index.ts
@@ -1,0 +1,34 @@
+export { DOMAIN_ERROR_CODES, isDomainError, toErrorResponse } from './errors.js';
+export type { DomainError, DomainErrorCode, ErrorResponse, ErrorResponseBody } from './errors.js';
+
+export type {
+  PostGroupsRequest,
+  PostInviteAcceptRequest,
+  PostClipsUploadUrlRequest,
+  PostClipsRequest,
+  PostVlogRetryRequest,
+  PostInviteRegenerateRequest,
+  GetGroupSlotsQuery,
+  GetSlotUrlsQuery,
+  PostCronHourlyTickRequest,
+  PostCronRawDeleteRequest,
+  PostCompileRequest,
+} from './requests.js';
+
+export type {
+  PostGroupsResponse,
+  PostInviteAcceptResponse,
+  PostClipsUploadUrlResponse,
+  PostClipsCreatedResponse,
+  PostClipsUpsertedResponse,
+  PostClipsResponse,
+  SlotSummary,
+  GetGroupSlotsResponse,
+  SlotUrlsClipEntry,
+  GetSlotUrlsResponse,
+  PostVlogRetryResponse,
+  PostInviteRegenerateResponse,
+  PostCronHourlyTickResponse,
+  PostCronRawDeleteResponse,
+  PostCompileResponse,
+} from './responses.js';

--- a/packages/domain/src/api/requests.ts
+++ b/packages/domain/src/api/requests.ts
@@ -1,0 +1,54 @@
+export interface PostGroupsRequest {
+  readonly name: string;
+  readonly timezone: string;
+  readonly activeHourStart: number;
+  readonly activeHourEnd: number;
+}
+
+export interface PostInviteAcceptRequest {
+  readonly code: string;
+}
+
+export interface PostClipsUploadUrlRequest {
+  readonly promptId: string;
+  readonly mimeType: 'video/mp4';
+  readonly fileSizeBytes: number;
+}
+
+export interface PostClipsRequest {
+  readonly promptId: string;
+  readonly storagePath: string;
+  readonly recordingStartedAt: string;
+  readonly fileSizeBytes: number;
+}
+
+export interface PostVlogRetryRequest {
+  readonly promptId: string;
+}
+
+export interface PostInviteRegenerateRequest {
+  readonly groupId: string;
+}
+
+export interface GetGroupSlotsQuery {
+  readonly groupId: string;
+  readonly date: string;
+}
+
+export interface GetSlotUrlsQuery {
+  readonly promptId: string;
+}
+
+export interface PostCronHourlyTickRequest {
+  readonly dispatchedAt: string;
+}
+
+export interface PostCronRawDeleteRequest {
+  readonly dispatchedAt: string;
+}
+
+export interface PostCompileRequest {
+  readonly promptId: string;
+  readonly groupId: string;
+  readonly triggerType: 'hourly-tick' | 'retry';
+}

--- a/packages/domain/src/api/responses.ts
+++ b/packages/domain/src/api/responses.ts
@@ -1,0 +1,94 @@
+import type { VlogState } from '../vlog/state.js';
+import type { UserFacingSlotStatus } from '../vlog/display.js';
+
+export interface PostGroupsResponse {
+  readonly groupId: string;
+  readonly inviteCode: string;
+  readonly inviteExpiresAt: string;
+}
+
+export interface PostInviteAcceptResponse {
+  readonly groupId: string;
+  readonly groupName: string;
+  readonly memberCount: number;
+}
+
+export interface PostClipsUploadUrlResponse {
+  readonly uploadUrl: string;
+  readonly expiresAt: string;
+  readonly storagePath: string;
+}
+
+export interface PostClipsCreatedResponse {
+  readonly clipId: string;
+  readonly promptId: string;
+  readonly status: 'uploaded';
+}
+
+export interface PostClipsUpsertedResponse extends PostClipsCreatedResponse {
+  readonly replaced: true;
+}
+
+export type PostClipsResponse = PostClipsCreatedResponse | PostClipsUpsertedResponse;
+
+export interface SlotSummary {
+  readonly promptId: string;
+  readonly slotStartsAt: string;
+  readonly status: 'open' | 'closed';
+  readonly outcome: VlogState extends { outcome: infer O } ? O : never;
+  readonly userFacingStatus: UserFacingSlotStatus;
+  readonly expired: boolean;
+  readonly clipCount: number;
+  readonly myClipExists: boolean;
+  readonly vlogUrl: string | null;
+  readonly clips: readonly never[];
+}
+
+export interface GetGroupSlotsResponse {
+  readonly groupId: string;
+  readonly date: string;
+  readonly slots: readonly SlotSummary[];
+}
+
+export interface SlotUrlsClipEntry {
+  readonly userId: string;
+  readonly displayName: string;
+  readonly clipUrl: string;
+}
+
+export interface GetSlotUrlsResponse {
+  readonly promptId: string;
+  readonly vlogUrl: string | null;
+  readonly clips: readonly SlotUrlsClipEntry[];
+}
+
+export interface PostVlogRetryResponse {
+  readonly status: 'pending';
+  readonly retryCount: number;
+  readonly message: string;
+}
+
+export interface PostInviteRegenerateResponse {
+  readonly inviteCode: string;
+  readonly inviteExpiresAt: string;
+}
+
+export interface PostCronHourlyTickResponse {
+  readonly promptsCreated: number;
+  readonly promptsClosed: number;
+  readonly pushesAttempted: number;
+  readonly pushesSucceeded: number;
+  readonly workersEnqueued: number;
+  readonly cronRunId: string;
+}
+
+export interface PostCronRawDeleteResponse {
+  readonly clipsDeleted: number;
+  readonly cronRunId: string;
+}
+
+export interface PostCompileResponse {
+  readonly status: 'done' | 'failed';
+  readonly outcome: 'compiled' | 'failed';
+  readonly vlogStoragePath: string | null;
+}

--- a/packages/domain/src/clip/index.ts
+++ b/packages/domain/src/clip/index.ts
@@ -1,0 +1,2 @@
+export type { ClipStatus, Clip, StoragePath } from './types.js';
+export { buildRawStoragePath } from './types.js';

--- a/packages/domain/src/clip/types.test.ts
+++ b/packages/domain/src/clip/types.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from '@jest/globals';
+import { buildRawStoragePath } from './types.js';
+
+describe('buildRawStoragePath', () => {
+  it('builds canonical path matching PRD §20.1', () => {
+    expect(buildRawStoragePath('g1', 'p1', 'u1')).toBe('raw/g1/p1/u1.mp4');
+  });
+
+  it('preserves UUID-like input verbatim', () => {
+    const g = '123e4567-e89b-12d3-a456-426614174000';
+    const p = '00000000-0000-0000-0000-000000000001';
+    const u = '00000000-0000-0000-0000-000000000002';
+    expect(buildRawStoragePath(g, p, u)).toBe(`raw/${g}/${p}/${u}.mp4`);
+  });
+});

--- a/packages/domain/src/clip/types.ts
+++ b/packages/domain/src/clip/types.ts
@@ -1,0 +1,25 @@
+export type ClipStatus = 'uploaded';
+
+export interface Clip {
+  readonly id: string;
+  readonly promptId: string;
+  readonly groupId: string;
+  readonly userId: string;
+  readonly storagePath: string;
+  readonly recordingStartedAt: string;
+  readonly uploadCompletedAt: string;
+  readonly rawDeleteAt: string;
+  readonly durationSec: number;
+  readonly fileSizeBytes: number;
+  readonly status: ClipStatus;
+  readonly isLate: boolean;
+  readonly createdAt: string;
+}
+
+export type StoragePath = `raw/${string}/${string}/${string}.mp4`;
+
+export const buildRawStoragePath = (
+  groupId: string,
+  promptId: string,
+  userId: string,
+): StoragePath => `raw/${groupId}/${promptId}/${userId}.mp4`;

--- a/packages/domain/src/group/index.ts
+++ b/packages/domain/src/group/index.ts
@@ -1,0 +1,1 @@
+export type { GroupMemberRole, Group, GroupMember } from './types.js';

--- a/packages/domain/src/group/types.ts
+++ b/packages/domain/src/group/types.ts
@@ -1,0 +1,22 @@
+export type GroupMemberRole = 'owner' | 'member';
+
+export interface Group {
+  readonly id: string;
+  readonly name: string;
+  readonly ownerId: string;
+  readonly timezone: string;
+  readonly activeHourStart: number;
+  readonly activeHourEnd: number;
+  readonly inviteCode: string;
+  readonly inviteExpiresAt: string;
+  readonly createdAt: string;
+}
+
+export interface GroupMember {
+  readonly groupId: string;
+  readonly userId: string;
+  readonly role: GroupMemberRole;
+  readonly consecutiveMissedCount: number;
+  readonly mutedUntil: string | null;
+  readonly joinedAt: string;
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,2 +1,6 @@
 export * as Shared from './shared/index.js';
 export * as Vlog from './vlog/index.js';
+export * as Slot from './slot/index.js';
+export * as Group from './group/index.js';
+export * as Clip from './clip/index.js';
+export * as Api from './api/index.js';

--- a/packages/domain/src/slot/index.ts
+++ b/packages/domain/src/slot/index.ts
@@ -1,0 +1,1 @@
+export type { PromptStatus, Prompt } from './prompt.js';

--- a/packages/domain/src/slot/prompt.ts
+++ b/packages/domain/src/slot/prompt.ts
@@ -1,0 +1,13 @@
+export type PromptStatus = 'open' | 'closed';
+
+export interface Prompt {
+  readonly id: string;
+  readonly groupId: string;
+  readonly slotStartsAt: string;
+  readonly slotEndsAt: string;
+  readonly graceEndsAt: string;
+  readonly expectedCount: number;
+  readonly uploadedCount: number;
+  readonly status: PromptStatus;
+  readonly createdAt: string;
+}

--- a/packages/domain/src/vlog/display.test.ts
+++ b/packages/domain/src/vlog/display.test.ts
@@ -1,0 +1,126 @@
+import { describe, test, expect } from '@jest/globals';
+import { toUserFacingStatus, type UserFacingSlotStatus } from './display.js';
+import type { VlogState } from './state.js';
+
+describe('vlog user-facing status mapping (PRD §8.5.1)', () => {
+  const cases: ReadonlyArray<{
+    readonly label: string;
+    readonly state: VlogState;
+    readonly rawExists: boolean;
+    readonly expected: UserFacingSlotStatus;
+  }> = [
+    {
+      label: '0 clips closed → empty',
+      state: { status: 'skipped', outcome: 'empty' },
+      rawExists: false,
+      expected: 'empty',
+    },
+    {
+      label: '1 clip closed → raw_only',
+      state: { status: 'skipped', outcome: 'skipped_single' },
+      rawExists: true,
+      expected: 'raw_only',
+    },
+    {
+      label: 'pending → processing',
+      state: { status: 'pending' },
+      rawExists: true,
+      expected: 'processing',
+    },
+    {
+      label: 'processing → processing',
+      state: { status: 'processing' },
+      rawExists: true,
+      expected: 'processing',
+    },
+    {
+      label: 'done compiled → compiled',
+      state: { status: 'done', outcome: 'compiled' },
+      rawExists: false,
+      expected: 'compiled',
+    },
+    {
+      label: 'failed with raw present → failed',
+      state: { status: 'failed', outcome: 'failed' },
+      rawExists: true,
+      expected: 'failed',
+    },
+    {
+      label: 'failed with raw already expired → expired',
+      state: { status: 'failed', outcome: 'failed' },
+      rawExists: false,
+      expected: 'expired',
+    },
+    {
+      label: 'failed with outcome=expired (terminal) → expired regardless of rawExists',
+      state: { status: 'failed', outcome: 'expired' },
+      rawExists: true,
+      expected: 'expired',
+    },
+  ];
+
+  test.each(cases)('$label', ({ state, rawExists, expected }) => {
+    expect(toUserFacingStatus(state, { rawExists })).toBe(expected);
+  });
+
+  describe('retry eligibility', () => {
+    test.each<{
+      label: string;
+      state: VlogState;
+      rawExists: boolean;
+      canRetry: boolean;
+    }>([
+      {
+        label: 'failed + raw present → can retry',
+        state: { status: 'failed', outcome: 'failed' },
+        rawExists: true,
+        canRetry: true,
+      },
+      {
+        label: 'failed + raw expired → cannot retry',
+        state: { status: 'failed', outcome: 'failed' },
+        rawExists: false,
+        canRetry: false,
+      },
+      {
+        label: 'failed + outcome=expired → cannot retry',
+        state: { status: 'failed', outcome: 'expired' },
+        rawExists: true,
+        canRetry: false,
+      },
+      {
+        label: 'compiled → cannot retry',
+        state: { status: 'done', outcome: 'compiled' },
+        rawExists: true,
+        canRetry: false,
+      },
+      {
+        label: 'processing → cannot retry (already in flight)',
+        state: { status: 'processing' },
+        rawExists: true,
+        canRetry: false,
+      },
+      {
+        label: 'pending → cannot retry (not yet failed)',
+        state: { status: 'pending' },
+        rawExists: true,
+        canRetry: false,
+      },
+      {
+        label: 'skipped empty → cannot retry',
+        state: { status: 'skipped', outcome: 'empty' },
+        rawExists: false,
+        canRetry: false,
+      },
+      {
+        label: 'skipped single → cannot retry',
+        state: { status: 'skipped', outcome: 'skipped_single' },
+        rawExists: true,
+        canRetry: false,
+      },
+    ])('$label', ({ state, rawExists, canRetry }) => {
+      const { canRetry: actual } = toUserFacingStatus.decide(state, { rawExists });
+      expect(actual).toBe(canRetry);
+    });
+  });
+});

--- a/packages/domain/src/vlog/display.ts
+++ b/packages/domain/src/vlog/display.ts
@@ -1,0 +1,65 @@
+import { assertNever } from '../shared/assert-never.js';
+import type { VlogState } from './state.js';
+
+export type UserFacingSlotStatus =
+  | 'empty'
+  | 'raw_only'
+  | 'processing'
+  | 'compiled'
+  | 'failed'
+  | 'expired';
+
+export interface ToUserFacingStatusContext {
+  readonly rawExists: boolean;
+}
+
+export interface UserFacingDecision {
+  readonly status: UserFacingSlotStatus;
+  readonly canRetry: boolean;
+}
+
+const decide = (state: VlogState, ctx: ToUserFacingStatusContext): UserFacingDecision => {
+  switch (state.status) {
+    case 'skipped':
+      switch (state.outcome) {
+        case 'empty':
+          return { status: 'empty', canRetry: false };
+        case 'skipped_single':
+          return { status: 'raw_only', canRetry: false };
+        /* istanbul ignore next -- exhaustiveness guard, unreachable by types */
+        default:
+          return assertNever(state);
+      }
+
+    case 'pending':
+    case 'processing':
+      return { status: 'processing', canRetry: false };
+
+    case 'done':
+      return { status: 'compiled', canRetry: false };
+
+    case 'failed':
+      if (state.outcome === 'expired') {
+        return { status: 'expired', canRetry: false };
+      }
+      if (!ctx.rawExists) {
+        return { status: 'expired', canRetry: false };
+      }
+      return { status: 'failed', canRetry: true };
+
+    /* istanbul ignore next -- exhaustiveness guard, unreachable by types */
+    default:
+      return assertNever(state);
+  }
+};
+
+type ToUserFacingStatusFn = {
+  (state: VlogState, ctx: ToUserFacingStatusContext): UserFacingSlotStatus;
+  readonly decide: typeof decide;
+};
+
+export const toUserFacingStatus: ToUserFacingStatusFn = Object.assign(
+  (state: VlogState, ctx: ToUserFacingStatusContext): UserFacingSlotStatus =>
+    decide(state, ctx).status,
+  { decide },
+);

--- a/packages/domain/src/vlog/index.ts
+++ b/packages/domain/src/vlog/index.ts
@@ -1,1 +1,9 @@
-export { transition, type VlogState, type VlogEvent } from './state.js';
+export { transition } from './state.js';
+export type { VlogState, VlogEvent } from './state.js';
+
+export { toUserFacingStatus } from './display.js';
+export type {
+  UserFacingSlotStatus,
+  ToUserFacingStatusContext,
+  UserFacingDecision,
+} from './display.js';


### PR DESCRIPTION
## 요약

플랜 Task-5 (이슈 #6) 구현. `packages/domain` 에 PRD 부록 B 와 §8.5.1 에 정의된 공개 API 요청·응답 DTO, 도메인 에러 12종, 슬롯 생명주기 상태와 유저 노출 상태 매핑을 **런타임 독립 순수 타입/함수** 로 정리합니다. 이 모듈은 앞으로 모바일 앱·Edge Functions·Cloud Run Worker 가 같은 정의를 참조할 단일 소스입니다.

## 변경 사항

### 새 모듈

- **`packages/domain/src/vlog/display.ts`**: `toUserFacingStatus(state, { rawExists })` 함수로 PRD §8.5.1 "정규 상태 매핑" 테이블을 그대로 구현. `status`·`canRetry` 를 동시에 반환하는 `decide` 유틸도 노출.
- **`packages/domain/src/api/errors.ts`**: 12종 `DomainError` discriminated union + `isDomainError` type guard + `toErrorResponse(error)` — 단일 소스에서 HTTP status (400/401/403/404/409/410/422/429) 와 한글 메시지·`details` 를 매핑. `DOMAIN_ERROR_CODES` 는 `Object.freeze` 된 const 튜플.
- **`packages/domain/src/api/requests.ts`**, **`responses.ts`**: 공개 7개 API + 내부 3개 API 의 요청·응답 DTO 를 모두 `readonly` 인터페이스로 정의.
- **`packages/domain/src/slot/prompt.ts`**: `Prompt` 와 `PromptStatus = 'open' | 'closed'` — PRD 부록 A 스키마 그대로.
- **`packages/domain/src/group/types.ts`**: `Group`, `GroupMember`, `GroupMemberRole`.
- **`packages/domain/src/clip/types.ts`**: `Clip`, `ClipStatus`, `buildRawStoragePath()` 헬퍼 + `StoragePath` template literal 타입으로 PRD §20.1 canonical path 를 컴파일 타임에 보장.

### 기존 모듈 확장

- `vlog/index.ts`: `display.ts` re-export 추가.
- 루트 `index.ts`: `Slot`, `Group`, `Clip`, `Api` 네임스페이스 4개 추가.

## 원칙 준수

- ARCHITECTURE.md §P-3: 순수 도메인. 외부 런타임 import 없음.
- ARCHITECTURE.md §P-4: 상태·에러 모두 discriminated union. 불법 상태는 표현 불가.
- CODING_STANDARDS.md §1.4: 모든 필드 `readonly`.
- CODING_STANDARDS.md §5.1: `any`, `as any`, `enum`, `namespace` 없음.
- CODING_STANDARDS.md §6.3: `DomainError` 코드값이 PRD 부록 B 와 1:1 일치.
- GR-13 TDD: 테스트 먼저 작성(RED)→구현(GREEN)→프리티어 정리(REFACTOR) 순서로 진행.

## 검증

- **pnpm --filter @momentlog/domain test**: **56/56 테스트 통과** (기존 28 + 신규 28).
- **pnpm --filter @momentlog/domain test:coverage**: `packages/domain` 100% — statements/branches/functions/lines 모두 유지.
- **pnpm typecheck**: 3개 workspace (domain/mobile/worker) 전부 통과.
- **pnpm format:check**: 전체 저장소 통과.
- 타입 선언만 있는 파일(`requests.ts`, `responses.ts`, `prompt.ts`, `group/types.ts`)은 Jest `collectCoverageFrom` 가 런타임 코드 부재로 자동 제외 — 커버리지 표에 나타나지 않지만 `tsc --noEmit` 이 보증.
- 불가능한 `default:` 분기(`assertNever` 호출)에는 `/* istanbul ignore next */` 툴링 지시자를 적용. 기존 `state.ts` 와 동일한 패턴.

## 체크리스트

- [x] 제목이 Conventional Commits 형식 (`feat(domain): task-5 — ...`)
- [x] 제목·본문 한글
- [x] 원자적 범위 (task-5 한 가지)
- [x] `pnpm typecheck` 통과
- [x] `pnpm --filter @momentlog/domain test:coverage` 100% 유지
- [x] `any`, `@ts-ignore`, non-null `!` 없음
- [x] 프로덕션 경로에 `console.log` / `console.error` 없음
- [x] PII / 시크릿 없음
- [x] 금지된 내부 문서 포함 없음 (guard 스크립트로 확인)
- [x] Closes #6

## 관련

- 플랜: `.sisyphus/plans/momentlog-mvp.md` Task 5 (Wave 1)
- 이슈: #6 — `[task-05] 공통 TypeScript 타입 정의 및 enum 상수`
- 이 모듈은 앞으로 모든 Edge Function / Worker / 모바일 앱이 API DTO·에러 매핑의 단일 소스로 삼습니다.