### PR TITLE
feat(domain): task-33 — clock skew / grace window / slot assignment 순수 로직 추가

### DIFF
--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -4,3 +4,4 @@ export * as Slot from './slot/index.js';
 export * as Group from './group/index.js';
 export * as Clip from './clip/index.js';
 export * as Api from './api/index.js';
+export * as Time from './time/index.js';

--- a/packages/domain/src/time/clock-skew.test.ts
+++ b/packages/domain/src/time/clock-skew.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from '@jest/globals';
+import { detectClockSkew, CLOCK_SKEW_TOLERANCE_MS } from './clock-skew.js';
+
+describe('detectClockSkew — PRD §8.4.1 (±5분 허용)', () => {
+  const server = '2026-04-24T12:00:00.000Z';
+
+  it('returns skewed=false when client and server are identical', () => {
+    const result = detectClockSkew({ clientTime: server, serverTime: server });
+    expect(result).toEqual({ skewed: false, skewMs: 0 });
+  });
+
+  it('accepts client +4:59 (within tolerance)', () => {
+    const client = '2026-04-24T12:04:59.000Z';
+    const { skewed } = detectClockSkew({ clientTime: client, serverTime: server });
+    expect(skewed).toBe(false);
+  });
+
+  it('accepts client -4:59 (within tolerance)', () => {
+    const client = '2026-04-24T11:55:01.000Z';
+    const { skewed } = detectClockSkew({ clientTime: client, serverTime: server });
+    expect(skewed).toBe(false);
+  });
+
+  it('accepts exactly at boundary of 5 minutes', () => {
+    const client = '2026-04-24T12:05:00.000Z';
+    const { skewed } = detectClockSkew({ clientTime: client, serverTime: server });
+    expect(skewed).toBe(false);
+  });
+
+  it('rejects client +6 minutes (beyond tolerance)', () => {
+    const client = '2026-04-24T12:06:00.000Z';
+    const { skewed, skewMs } = detectClockSkew({ clientTime: client, serverTime: server });
+    expect(skewed).toBe(true);
+    expect(skewMs).toBe(6 * 60 * 1000);
+  });
+
+  it('rejects client -6 minutes (beyond tolerance)', () => {
+    const client = '2026-04-24T11:54:00.000Z';
+    const { skewed, skewMs } = detectClockSkew({ clientTime: client, serverTime: server });
+    expect(skewed).toBe(true);
+    expect(skewMs).toBe(-6 * 60 * 1000);
+  });
+
+  it('uses custom toleranceMs when provided', () => {
+    const client = '2026-04-24T12:01:00.000Z';
+    const result = detectClockSkew({
+      clientTime: client,
+      serverTime: server,
+      toleranceMs: 30 * 1000,
+    });
+    expect(result.skewed).toBe(true);
+    expect(result.skewMs).toBe(60 * 1000);
+  });
+
+  it('exposes CLOCK_SKEW_TOLERANCE_MS as 5 minutes', () => {
+    expect(CLOCK_SKEW_TOLERANCE_MS).toBe(5 * 60 * 1000);
+  });
+
+  it('throws on invalid clientTime', () => {
+    expect(() => detectClockSkew({ clientTime: 'bad', serverTime: server })).toThrow(
+      /invalid clientTime/i,
+    );
+  });
+
+  it('throws on invalid serverTime', () => {
+    expect(() => detectClockSkew({ clientTime: server, serverTime: 'bad' })).toThrow(
+      /invalid serverTime/i,
+    );
+  });
+});

--- a/packages/domain/src/time/clock-skew.ts
+++ b/packages/domain/src/time/clock-skew.ts
@@ -1,0 +1,31 @@
+export const CLOCK_SKEW_TOLERANCE_MS = 5 * 60 * 1000;
+
+export interface DetectClockSkewInput {
+  readonly clientTime: string;
+  readonly serverTime: string;
+  readonly toleranceMs?: number;
+}
+
+export interface ClockSkewResult {
+  readonly skewed: boolean;
+  readonly skewMs: number;
+}
+
+export const detectClockSkew = (input: DetectClockSkewInput): ClockSkewResult => {
+  const { clientTime, serverTime, toleranceMs = CLOCK_SKEW_TOLERANCE_MS } = input;
+  const clientMs = parseIso(clientTime, 'clientTime');
+  const serverMs = parseIso(serverTime, 'serverTime');
+  const skewMs = clientMs - serverMs;
+  return {
+    skewed: Math.abs(skewMs) > toleranceMs,
+    skewMs,
+  };
+};
+
+const parseIso = (iso: string, field: string): number => {
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) {
+    throw new Error(`invalid ${field}: ${iso}`);
+  }
+  return ms;
+};

--- a/packages/domain/src/time/grace-window.test.ts
+++ b/packages/domain/src/time/grace-window.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  GRACE_WINDOW_MIN,
+  computeSlotWindow,
+  isWithinGraceWindow,
+  type SlotWindow,
+} from './grace-window.js';
+
+describe('GRACE_WINDOW_MIN', () => {
+  it('is exactly 15 minutes per PRD §8.4', () => {
+    expect(GRACE_WINDOW_MIN).toBe(15);
+  });
+});
+
+describe('computeSlotWindow', () => {
+  it('derives slotEndsAt = slotStartsAt + 1 hour and graceEndsAt = slotEndsAt + 15min', () => {
+    const w: SlotWindow = computeSlotWindow({ slotStartsAt: '2026-04-24T12:00:00.000Z' });
+    expect(w.slotStartsAt).toBe('2026-04-24T12:00:00.000Z');
+    expect(w.slotEndsAt).toBe('2026-04-24T13:00:00.000Z');
+    expect(w.graceEndsAt).toBe('2026-04-24T13:15:00.000Z');
+  });
+
+  it('respects custom slotDurationMin', () => {
+    const w = computeSlotWindow({
+      slotStartsAt: '2026-04-24T12:00:00.000Z',
+      slotDurationMin: 30,
+    });
+    expect(w.slotEndsAt).toBe('2026-04-24T12:30:00.000Z');
+    expect(w.graceEndsAt).toBe('2026-04-24T12:45:00.000Z');
+  });
+
+  it('respects custom graceDurationMin', () => {
+    const w = computeSlotWindow({
+      slotStartsAt: '2026-04-24T12:00:00.000Z',
+      graceDurationMin: 5,
+    });
+    expect(w.slotEndsAt).toBe('2026-04-24T13:00:00.000Z');
+    expect(w.graceEndsAt).toBe('2026-04-24T13:05:00.000Z');
+  });
+
+  it('throws on invalid slotStartsAt', () => {
+    expect(() => computeSlotWindow({ slotStartsAt: 'not-a-date' })).toThrow(
+      /invalid slotStartsAt/i,
+    );
+  });
+});
+
+describe('isWithinGraceWindow — PRD §8.4 (slot_end + 15분)', () => {
+  const graceEndsAt = '2026-04-24T13:15:00.000Z';
+
+  it('accepts finalizeAt 1ms before grace end', () => {
+    expect(isWithinGraceWindow({ finalizeAt: '2026-04-24T13:14:59.999Z', graceEndsAt })).toBe(true);
+  });
+
+  it('accepts finalizeAt exactly at grace end (inclusive boundary)', () => {
+    expect(isWithinGraceWindow({ finalizeAt: '2026-04-24T13:15:00.000Z', graceEndsAt })).toBe(true);
+  });
+
+  it('rejects finalizeAt 1ms after grace end (exclusive beyond)', () => {
+    expect(isWithinGraceWindow({ finalizeAt: '2026-04-24T13:15:00.001Z', graceEndsAt })).toBe(
+      false,
+    );
+  });
+
+  it('accepts finalizeAt earlier than slot end', () => {
+    expect(isWithinGraceWindow({ finalizeAt: '2026-04-24T12:30:00.000Z', graceEndsAt })).toBe(true);
+  });
+
+  it('throws on invalid finalizeAt', () => {
+    expect(() => isWithinGraceWindow({ finalizeAt: 'nope', graceEndsAt })).toThrow(
+      /invalid finalizeAt/i,
+    );
+  });
+
+  it('throws on invalid graceEndsAt', () => {
+    expect(() => isWithinGraceWindow({ finalizeAt: graceEndsAt, graceEndsAt: 'nope' })).toThrow(
+      /invalid graceEndsAt/i,
+    );
+  });
+});

--- a/packages/domain/src/time/grace-window.ts
+++ b/packages/domain/src/time/grace-window.ts
@@ -1,0 +1,49 @@
+export const GRACE_WINDOW_MIN = 15;
+const DEFAULT_SLOT_DURATION_MIN = 60;
+
+export interface ComputeSlotWindowInput {
+  readonly slotStartsAt: string;
+  readonly slotDurationMin?: number;
+  readonly graceDurationMin?: number;
+}
+
+export interface SlotWindow {
+  readonly slotStartsAt: string;
+  readonly slotEndsAt: string;
+  readonly graceEndsAt: string;
+}
+
+export const computeSlotWindow = (input: ComputeSlotWindowInput): SlotWindow => {
+  const {
+    slotStartsAt,
+    slotDurationMin = DEFAULT_SLOT_DURATION_MIN,
+    graceDurationMin = GRACE_WINDOW_MIN,
+  } = input;
+  const startMs = parseIso(slotStartsAt, 'slotStartsAt');
+  const endMs = startMs + slotDurationMin * 60 * 1000;
+  const graceMs = endMs + graceDurationMin * 60 * 1000;
+  return {
+    slotStartsAt: new Date(startMs).toISOString(),
+    slotEndsAt: new Date(endMs).toISOString(),
+    graceEndsAt: new Date(graceMs).toISOString(),
+  };
+};
+
+export interface IsWithinGraceWindowInput {
+  readonly finalizeAt: string;
+  readonly graceEndsAt: string;
+}
+
+export const isWithinGraceWindow = (input: IsWithinGraceWindowInput): boolean => {
+  const finalizeMs = parseIso(input.finalizeAt, 'finalizeAt');
+  const graceMs = parseIso(input.graceEndsAt, 'graceEndsAt');
+  return finalizeMs <= graceMs;
+};
+
+const parseIso = (iso: string, field: string): number => {
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) {
+    throw new Error(`invalid ${field}: ${iso}`);
+  }
+  return ms;
+};

--- a/packages/domain/src/time/index.ts
+++ b/packages/domain/src/time/index.ts
@@ -1,0 +1,12 @@
+export { CLOCK_SKEW_TOLERANCE_MS, detectClockSkew } from './clock-skew.js';
+export type { DetectClockSkewInput, ClockSkewResult } from './clock-skew.js';
+
+export { GRACE_WINDOW_MIN, computeSlotWindow, isWithinGraceWindow } from './grace-window.js';
+export type {
+  ComputeSlotWindowInput,
+  SlotWindow,
+  IsWithinGraceWindowInput,
+} from './grace-window.js';
+
+export { assignSlotByRecordingStart } from './slot-assignment.js';
+export type { CandidateSlot, AssignSlotInput, AssignSlotResult } from './slot-assignment.js';

--- a/packages/domain/src/time/slot-assignment.test.ts
+++ b/packages/domain/src/time/slot-assignment.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from '@jest/globals';
+import { assignSlotByRecordingStart, type CandidateSlot } from './slot-assignment.js';
+
+const slots: readonly CandidateSlot[] = [
+  {
+    promptId: 'slot-11',
+    slotStartsAt: '2026-04-24T11:00:00.000Z',
+    slotEndsAt: '2026-04-24T12:00:00.000Z',
+  },
+  {
+    promptId: 'slot-12',
+    slotStartsAt: '2026-04-24T12:00:00.000Z',
+    slotEndsAt: '2026-04-24T13:00:00.000Z',
+  },
+];
+
+describe('assignSlotByRecordingStart — PRD §8.4.1', () => {
+  it('selects slot when recordingStartedAt is exactly at slotStartsAt', () => {
+    const r = assignSlotByRecordingStart({
+      recordingStartedAt: '2026-04-24T12:00:00.000Z',
+      candidates: slots,
+    });
+    expect(r).toEqual({ ok: true, promptId: 'slot-12' });
+  });
+
+  it('selects slot when recordingStartedAt is mid-slot', () => {
+    const r = assignSlotByRecordingStart({
+      recordingStartedAt: '2026-04-24T12:30:00.000Z',
+      candidates: slots,
+    });
+    expect(r).toEqual({ ok: true, promptId: 'slot-12' });
+  });
+
+  it('selects slot when recordingStartedAt is 1ms before slotEndsAt', () => {
+    const r = assignSlotByRecordingStart({
+      recordingStartedAt: '2026-04-24T12:59:59.999Z',
+      candidates: slots,
+    });
+    expect(r).toEqual({ ok: true, promptId: 'slot-12' });
+  });
+
+  it('assigns the later slot when recordingStartedAt is exactly at slotEndsAt (half-open boundary [start, end))', () => {
+    const r = assignSlotByRecordingStart({
+      recordingStartedAt: '2026-04-24T12:00:00.000Z',
+      candidates: slots,
+    });
+    expect(r).toEqual({ ok: true, promptId: 'slot-12' });
+  });
+
+  it('returns MISMATCH when recordingStartedAt is before all slots', () => {
+    const r = assignSlotByRecordingStart({
+      recordingStartedAt: '2026-04-24T10:30:00.000Z',
+      candidates: slots,
+    });
+    expect(r).toEqual({ ok: false, reason: 'NO_MATCHING_SLOT' });
+  });
+
+  it('returns MISMATCH when recordingStartedAt is after all slots', () => {
+    const r = assignSlotByRecordingStart({
+      recordingStartedAt: '2026-04-24T13:30:00.000Z',
+      candidates: slots,
+    });
+    expect(r).toEqual({ ok: false, reason: 'NO_MATCHING_SLOT' });
+  });
+
+  it('returns MISMATCH when candidates is empty', () => {
+    const r = assignSlotByRecordingStart({
+      recordingStartedAt: '2026-04-24T12:00:00.000Z',
+      candidates: [],
+    });
+    expect(r).toEqual({ ok: false, reason: 'NO_MATCHING_SLOT' });
+  });
+
+  it('throws on invalid recordingStartedAt', () => {
+    expect(() =>
+      assignSlotByRecordingStart({
+        recordingStartedAt: 'nope',
+        candidates: slots,
+      }),
+    ).toThrow(/invalid recordingStartedAt/i);
+  });
+
+  it('throws on invalid candidate slotStartsAt', () => {
+    expect(() =>
+      assignSlotByRecordingStart({
+        recordingStartedAt: '2026-04-24T12:00:00.000Z',
+        candidates: [{ promptId: 'x', slotStartsAt: 'bad', slotEndsAt: 'bad' }],
+      }),
+    ).toThrow(/invalid candidate/i);
+  });
+});

--- a/packages/domain/src/time/slot-assignment.ts
+++ b/packages/domain/src/time/slot-assignment.ts
@@ -1,0 +1,34 @@
+export interface CandidateSlot {
+  readonly promptId: string;
+  readonly slotStartsAt: string;
+  readonly slotEndsAt: string;
+}
+
+export interface AssignSlotInput {
+  readonly recordingStartedAt: string;
+  readonly candidates: readonly CandidateSlot[];
+}
+
+export type AssignSlotResult =
+  | { readonly ok: true; readonly promptId: string }
+  | { readonly ok: false; readonly reason: 'NO_MATCHING_SLOT' };
+
+export const assignSlotByRecordingStart = (input: AssignSlotInput): AssignSlotResult => {
+  const recordingMs = parseIso(input.recordingStartedAt, 'recordingStartedAt');
+  for (const slot of input.candidates) {
+    const startMs = parseIso(slot.slotStartsAt, `candidate[${slot.promptId}].slotStartsAt`);
+    const endMs = parseIso(slot.slotEndsAt, `candidate[${slot.promptId}].slotEndsAt`);
+    if (recordingMs >= startMs && recordingMs < endMs) {
+      return { ok: true, promptId: slot.promptId };
+    }
+  }
+  return { ok: false, reason: 'NO_MATCHING_SLOT' };
+};
+
+const parseIso = (iso: string, field: string): number => {
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) {
+    throw new Error(`invalid ${field}: ${iso}`);
+  }
+  return ms;
+};


### PR DESCRIPTION
## 요약

플랜 Task-33 (이슈 #34) 구현. 서버측 time validation 에 쓰일 세 가지 순수 함수를 `packages/domain/src/time/` 에 추가합니다. PRD §8.4.1 의 clock skew (±5분), §8.4 의 grace window (15분), §8.4.1 의 slot 귀속 규칙을 런타임 독립으로 정규화했습니다. DST 처리는 ARCHITECTURE.md §10.1 / CODING_STANDARDS.md §10 에 따라 **Postgres `AT TIME ZONE`** 이 담당하고, domain 레이어는 **UTC millisecond 비교**만 수행합니다.

## 변경 사항

### `packages/domain/src/time/clock-skew.ts`
- `CLOCK_SKEW_TOLERANCE_MS = 5 * 60 * 1000` 상수와 `detectClockSkew({ clientTime, serverTime, toleranceMs? })` 함수.
- 기본 허용치 ±5분이며, 경계 정확히 5:00 은 수용, 5:01 이상만 거부.
- `skewMs` 는 부호가 있어 (client - server) 방향을 보존합니다.

### `packages/domain/src/time/grace-window.ts`
- `GRACE_WINDOW_MIN = 15`
- `computeSlotWindow({ slotStartsAt, slotDurationMin?=60, graceDurationMin?=15 })` → `{ slotStartsAt, slotEndsAt, graceEndsAt }`.
- `isWithinGraceWindow({ finalizeAt, graceEndsAt })` → boolean. 인클루시브 end: `22:15:00.000` 은 수용, `22:15:00.001` 은 거부. 플랜 Acceptance Criteria 와 일치.

### `packages/domain/src/time/slot-assignment.ts`
- `assignSlotByRecordingStart({ recordingStartedAt, candidates })` → `{ ok: true, promptId } | { ok: false, reason: 'NO_MATCHING_SLOT' }`.
- **반개구간 [start, end)** 매칭. `recordingStartedAt` 이 직전 슬롯의 `slotEndsAt` 과 동일하면 **다음 슬롯으로 귀속** (PRD §8.4.1 서버 권위).
- 매칭 실패 시 `NO_MATCHING_SLOT` 반환 (throw 하지 않음, Result 패턴).

### 입력 검증
- 모든 함수가 ISO 8601 문자열을 `Date.parse` 로 파싱하고 NaN 이면 `invalid {field}: {value}` 메시지로 throw. 도메인 경계(컴파일러가 잡지 못하는 런타임 invariant)에서 **Fail Fast** (CODING_STANDARDS §1.3, §6.1).

### re-export
- `packages/domain/src/index.ts` 에 `Time` 네임스페이스 추가.

## 원칙 준수

- ARCHITECTURE.md §P-3: domain 순수. `Date.now()` 사용 없음. 인자로 받은 ISO 문자열만 비교.
- ARCHITECTURE.md §10.1 / CODING_STANDARDS.md §10: DST 처리는 Postgres 책임. domain 은 UTC ms 비교만.
- CODING_STANDARDS §1.4 / §1.5: 모든 입력/반환 `readonly`, Result 패턴 사용.
- CODING_STANDARDS §6.1: 도메인 에러는 Result 로, 경계 invariant 위반은 throw.

## 검증

- **pnpm --filter @momentlog/domain test:coverage**: **86/86 테스트 통과** (이전 56 + 신규 30), 커버리지 `statements/branches/functions/lines` 모두 **100%** 유지.
- **pnpm typecheck**: 3개 workspace 전부 통과.
- **pnpm format:check**: 전체 저장소 통과.
- 플랜 Acceptance Criteria 대응:
  - grace 22:15:00.000 수용 / 22:15:00.001 거부 → grace-window.test.ts 의 "accepts finalizeAt exactly at grace end" / "rejects finalizeAt 1ms after grace end" 케이스.
  - clock skew +6분 거부 → clock-skew.test.ts 의 "rejects client +6 minutes".
  - DST 처리는 Postgres 에서 담당 (task-7 migration 및 task-20 cron 에서 구현).

## 체크리스트

- [x] 제목이 Conventional Commits 형식
- [x] 제목·본문 한글
- [x] 원자적 범위 (task-33 한 가지)
- [x] `pnpm typecheck` 통과
- [x] `@momentlog/domain` 커버리지 100% 유지
- [x] `any`, `@ts-ignore`, non-null `!` 없음
- [x] 프로덕션 경로에 `console.log` / `console.error` 없음
- [x] PII / 시크릿 없음
- [x] 금지된 내부 문서 포함 없음
- [x] Closes #34

## 관련

- 플랜: `.sisyphus/plans/momentlog-mvp.md` Task 33 (Wave 6)
- 이슈: #34 — `[task-33] Edge case 처리 — clock skew / DST / grace boundary`
- 이 모듈은 task-18(`clips-finalize`), task-20(`cron-hourly-tick`), task-22(`groups-slots`) 에서 import 해서 서버측 validation 에 사용합니다.