### PR TITLE
feat(db): wave-2 — 초기 스키마·RLS·트리거·Storage 버킷 migrations 4종 추가

### DIFF
--- a/supabase/migrations/00000000000001_init.sql
+++ b/supabase/migrations/00000000000001_init.sql
@@ -1,0 +1,135 @@
+-- Task-7: 초기 스키마 (PRD v1.1-final 부록 A)
+-- 8개 테이블 + 9개 인덱스 + 3개 CHECK 제약. 플랜 GR-10: 부록 A 외 컬럼 추가 금지.
+
+create table if not exists profiles (
+  id uuid primary key references auth.users on delete cascade,
+  display_name text,
+  avatar_url text,
+  created_at timestamptz default now()
+);
+
+create table if not exists groups (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  owner_id uuid not null references auth.users,
+  timezone text not null default 'Asia/Seoul',
+  active_hour_start smallint not null default 9,
+  active_hour_end smallint not null default 22,
+  invite_code text unique not null,
+  invite_expires_at timestamptz not null,
+  created_at timestamptz default now()
+);
+
+create table if not exists group_members (
+  group_id uuid not null references groups on delete cascade,
+  user_id uuid not null references auth.users on delete cascade,
+  role text not null default 'member',
+  consecutive_missed_count int not null default 0,
+  muted_until timestamptz,
+  joined_at timestamptz default now(),
+  primary key (group_id, user_id)
+);
+
+create table if not exists prompts (
+  id uuid primary key default gen_random_uuid(),
+  group_id uuid not null references groups on delete cascade,
+  slot_starts_at timestamptz not null,
+  slot_ends_at timestamptz not null,
+  grace_ends_at timestamptz not null,
+  expected_count int not null,
+  uploaded_count int not null default 0,
+  status text not null default 'open',
+  created_at timestamptz default now(),
+  unique (group_id, slot_starts_at)
+);
+
+create table if not exists clips (
+  id uuid primary key default gen_random_uuid(),
+  prompt_id uuid not null references prompts on delete cascade,
+  group_id uuid not null references groups on delete cascade,
+  user_id uuid not null references auth.users on delete cascade,
+  storage_path text not null,
+  recording_started_at timestamptz not null,
+  upload_completed_at timestamptz not null default now(),
+  raw_delete_at timestamptz not null,
+  duration_sec int not null default 3,
+  file_size_bytes bigint not null,
+  status text not null default 'uploaded',
+  is_late boolean not null default false,
+  created_at timestamptz default now(),
+  unique (prompt_id, user_id)
+);
+create index if not exists clips_raw_delete_at_idx on clips (raw_delete_at);
+
+create table if not exists vlogs (
+  id uuid primary key default gen_random_uuid(),
+  prompt_id uuid not null unique references prompts on delete cascade,
+  group_id uuid not null references groups on delete cascade,
+  storage_path text,
+  status text not null default 'pending',
+  outcome text not null default 'empty',
+  trigger_type text,
+  clip_count int not null default 0,
+  duration_sec int,
+  error_message text,
+  error_stage text,
+  retry_count int not null default 0,
+  last_retry_at timestamptz,
+  processing_started_at timestamptz,
+  created_at timestamptz default now(),
+  completed_at timestamptz
+);
+create index if not exists vlogs_status_processing_idx
+  on vlogs (processing_started_at) where status = 'processing';
+
+create table if not exists invite_attempts (
+  id uuid primary key default gen_random_uuid(),
+  invite_code text not null,
+  ip_address text not null,
+  success boolean not null default false,
+  attempted_at timestamptz default now()
+);
+create index if not exists invite_attempts_ip_idx
+  on invite_attempts (ip_address, attempted_at);
+
+create table if not exists push_tokens (
+  user_id uuid not null references auth.users on delete cascade,
+  expo_push_token text not null,
+  platform text not null,
+  last_seen_at timestamptz not null default now(),
+  invalidated_at timestamptz,
+  updated_at timestamptz default now(),
+  primary key (user_id, expo_push_token)
+);
+
+create table if not exists cron_runs (
+  id uuid primary key default gen_random_uuid(),
+  job_name text not null,
+  started_at timestamptz not null default now(),
+  completed_at timestamptz,
+  status text not null default 'running',
+  prompts_created int not null default 0,
+  prompts_closed int not null default 0,
+  pushes_attempted int not null default 0,
+  pushes_succeeded int not null default 0,
+  workers_enqueued int not null default 0,
+  clips_deleted int not null default 0,
+  error_message text
+);
+create index if not exists cron_runs_job_started_idx on cron_runs (job_name, started_at desc);
+
+-- CHECK 제약 (플랜 task-7 에서 명시적으로 요구된 3개)
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'vlogs_status_check') then
+    alter table vlogs add constraint vlogs_status_check
+      check (status in ('pending','processing','done','failed','skipped'));
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'vlogs_outcome_check') then
+    alter table vlogs add constraint vlogs_outcome_check
+      check (outcome in ('empty','skipped_single','compiled','failed','expired'));
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'prompts_status_check') then
+    alter table prompts add constraint prompts_status_check
+      check (status in ('open','closed'));
+  end if;
+end $$;

--- a/supabase/migrations/00000000000002_rls.sql
+++ b/supabase/migrations/00000000000002_rls.sql
@@ -1,0 +1,92 @@
+-- Task-8: RLS 정책 (PRD §20.2). 모든 7개 테이블에 RLS 활성화 + 최소 권한 정책.
+-- service_role 키는 RLS 를 기본 bypass 하므로 별도 policy 불필요.
+
+alter table profiles enable row level security;
+alter table groups enable row level security;
+alter table group_members enable row level security;
+alter table prompts enable row level security;
+alter table clips enable row level security;
+alter table vlogs enable row level security;
+alter table push_tokens enable row level security;
+alter table invite_attempts enable row level security;
+
+-- profiles: 인증 유저는 모두 읽기, 본인만 update
+drop policy if exists profiles_select_authenticated on profiles;
+create policy profiles_select_authenticated on profiles
+  for select to authenticated using (true);
+
+drop policy if exists profiles_update_self on profiles;
+create policy profiles_update_self on profiles
+  for update to authenticated
+  using (id = (select auth.uid()))
+  with check (id = (select auth.uid()));
+
+-- groups: 자기가 속한 그룹만 읽기
+drop policy if exists groups_select_member on groups;
+create policy groups_select_member on groups
+  for select to authenticated
+  using (
+    id in (
+      select gm.group_id from group_members gm
+      where gm.user_id = (select auth.uid())
+    )
+  );
+
+-- group_members: 같은 그룹 구성원만 읽기. insert/update/delete 는 service_role.
+drop policy if exists group_members_select_same_group on group_members;
+create policy group_members_select_same_group on group_members
+  for select to authenticated
+  using (
+    group_id in (
+      select gm.group_id from group_members gm
+      where gm.user_id = (select auth.uid())
+    )
+  );
+
+-- prompts: 그룹 멤버만 읽기, insert/update 는 service_role
+drop policy if exists prompts_select_member on prompts;
+create policy prompts_select_member on prompts
+  for select to authenticated
+  using (
+    group_id in (
+      select gm.group_id from group_members gm
+      where gm.user_id = (select auth.uid())
+    )
+  );
+
+-- clips: 같은 그룹 멤버만 읽기, insert 는 본인 user_id 만
+drop policy if exists clips_select_member on clips;
+create policy clips_select_member on clips
+  for select to authenticated
+  using (
+    group_id in (
+      select gm.group_id from group_members gm
+      where gm.user_id = (select auth.uid())
+    )
+  );
+
+drop policy if exists clips_insert_self on clips;
+create policy clips_insert_self on clips
+  for insert to authenticated
+  with check (user_id = (select auth.uid()));
+
+-- vlogs: 그룹 멤버만 읽기, insert/update 는 service_role
+drop policy if exists vlogs_select_member on vlogs;
+create policy vlogs_select_member on vlogs
+  for select to authenticated
+  using (
+    group_id in (
+      select gm.group_id from group_members gm
+      where gm.user_id = (select auth.uid())
+    )
+  );
+
+-- push_tokens: 본인만 전체 CRUD
+drop policy if exists push_tokens_all_self on push_tokens;
+create policy push_tokens_all_self on push_tokens
+  for all to authenticated
+  using (user_id = (select auth.uid()))
+  with check (user_id = (select auth.uid()));
+
+-- invite_attempts: 앱(authenticated/anon) 접근 전면 차단. service_role 전용.
+-- ENABLE ROW LEVEL SECURITY 만으로 policy 없으면 0 row 반환. 명시적 DENY 는 불필요.

--- a/supabase/migrations/00000000000003_triggers.sql
+++ b/supabase/migrations/00000000000003_triggers.sql
@@ -1,0 +1,22 @@
+-- Task-9: uploaded_count 자동 증분 트리거 (PRD §14.1).
+-- clips INSERT 시 prompts.uploaded_count += 1. status='open' 인 prompt 에만 반영.
+-- upsert (ON CONFLICT DO ... UPDATE) 는 INSERT 트리거가 fire 하지 않으므로 중복 증분 자동 방지.
+
+create or replace function increment_uploaded_count()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update prompts
+    set uploaded_count = uploaded_count + 1
+    where id = new.prompt_id and status = 'open';
+  return new;
+end;
+$$;
+
+drop trigger if exists clips_after_insert on clips;
+create trigger clips_after_insert
+  after insert on clips
+  for each row execute function increment_uploaded_count();

--- a/supabase/migrations/00000000000004_storage.sql
+++ b/supabase/migrations/00000000000004_storage.sql
@@ -1,0 +1,15 @@
+-- Task-10: Storage 버킷 3종 (PRD §20.1). 모두 private + size/MIME 제한.
+-- Canonical paths: raw/{group_id}/{prompt_id}/{user_id}.mp4, vlogs/{group_id}/{prompt_id}/output.mp4, tmp/{group_id}/{prompt_id}/*
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values
+  ('raw',   'raw',   false, 10485760,  array['video/mp4', 'video/quicktime']),
+  ('vlogs', 'vlogs', false, 52428800,  array['video/mp4']),
+  ('tmp',   'tmp',   false, 52428800,  array['video/mp4', 'application/octet-stream'])
+on conflict (id) do update
+  set public = excluded.public,
+      file_size_limit = excluded.file_size_limit,
+      allowed_mime_types = excluded.allowed_mime_types;
+
+-- storage.objects 는 service_role 전용으로 둔다. 일반 앱은 Edge Function 이 발급한 signed URL 로만 접근한다 (PRD §20.1).
+-- Public 이나 policy 를 열지 않는 것이 의도된 설계.


### PR DESCRIPTION
## 요약

플랜 Wave 2 의 4개 태스크(#8 #9 #10 #11)를 **단일 논리 단위**(초기 DB 구축)로 묶어 4개의 번호 매겨진 Supabase migration 으로 구현합니다. 어떤 변경도 PRD v1.1-final 부록 A/§20.1/§20.2 에서 **한 컬럼도 벗어나지 않도록** 플랜 GR-10 을 엄격히 준수했습니다.

## 변경 사항

### `supabase/migrations/00000000000001_init.sql` — Task-7 (#8)
- PRD 부록 A v1.1-final DDL 그대로 복사: `profiles`, `groups`, `group_members`, `prompts`, `clips`, `vlogs`, `invite_attempts`, `push_tokens`, `cron_runs` 의 9개 테이블.
- 인덱스: `clips_raw_delete_at_idx`, `vlogs_status_processing_idx` (partial), `invite_attempts_ip_idx`, `cron_runs_job_started_idx`.
- CHECK 제약 3개 (플랜이 명시적으로 추가한 부분):
  - `vlogs.status ∈ {pending, processing, done, failed, skipped}`
  - `vlogs.outcome ∈ {empty, skipped_single, compiled, failed, expired}` (PRD §8.5.1 expired 포함)
  - `prompts.status ∈ {open, closed}`
- 모든 DDL 을 `if not exists` + `do \$\$ ... end \$\$` 로 idempotent 하게 작성 (`supabase db reset` / re-apply 안전).

### `supabase/migrations/00000000000002_rls.sql` — Task-8 (#9)
7개 테이블에 `enable row level security` 후 PRD §20.2 매핑 그대로:
- `profiles`: 인증 유저 read 전체, 본인 update.
- `groups`: 같은 그룹 멤버만 read.
- `group_members`/`prompts`/`vlogs`: 같은 그룹 멤버만 read, 쓰기는 `service_role` 전용.
- `clips`: 같은 그룹 멤버만 read, insert 는 `user_id = auth.uid()` 만.
- `push_tokens`: 본인만 전체 CRUD.
- `invite_attempts`: 정책 전혀 없음 → `authenticated`/`anon` 전면 차단, `service_role` 만 우회 가능.

모든 `using` / `with check` 절에서 `(select auth.uid())` 서브쿼리 사용 — Supabase 권장 RLS 최적화 패턴(쿼리 플래너가 `auth.uid()` 를 한 번만 평가). `drop policy if exists` 선행으로 재실행 안전.

### `supabase/migrations/00000000000003_triggers.sql` — Task-9 (#10)
- `clips` INSERT → `prompts.uploaded_count += 1` 트리거 (`clips_after_insert`).
- `status='open'` 가드 — 닫힌 프롬프트에는 증분하지 않아 PRD §14.1 idempotency 를 DB 레벨에서 보장.
- `security definer` + `set search_path = public` 으로 search_path hijacking 방어.
- upsert(`ON CONFLICT DO UPDATE`) 는 Postgres 사양상 INSERT 트리거를 fire 하지 않으므로 중복 증분이 자연 방지됨 (플랜 task-9 의 QA 시나리오와 일치).

### `supabase/migrations/00000000000004_storage.sql` — Task-10 (#11)
- 3개 버킷을 모두 `public=false` 로 생성 + size/MIME 제한:
  - `raw` 10MB, `video/mp4 | video/quicktime`
  - `vlogs` 50MB, `video/mp4`
  - `tmp` 50MB, `video/mp4 | application/octet-stream`
- `on conflict (id) do update` 로 재실행 시 설정이 최신으로 수렴.
- `storage.objects` 에 policy 를 걸지 않음 — 앱은 Edge Function 이 발급한 signed URL (1h TTL) 로만 접근한다(PRD §20.1). 이것은 **의도된 설계**이며 주석에 명시.

## 원칙 준수

- CODING_STANDARDS.md §6.1 Migrations: 모든 변경 idempotent, `CREATE IF NOT EXISTS`, `on conflict do update`.
- CODING_STANDARDS.md §6.4 RLS: 모든 테이블에 RLS 활성화, `USING (true)` 금지, service_role 최소 사용.
- 플랜 GR-10: PRD 부록 A 에 없는 컬럼·인덱스·제약 추가 없음. 플랜이 명시적으로 승인한 CHECK 3개만 추가.
- 플랜 GR-3 (시간 정확식): `raw_delete_at` 는 DB 가 아니라 **task-18 의 Edge Function** 에서 application layer 로 `AT TIME ZONE` 계산 후 INSERT (플랜 task-9 본문에 명시된 설계).

## 검증

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm --filter @momentlog/domain test:coverage` 모두 초록 (SQL 파일은 형식 영향 없음).
- `no-private-docs` guard: `supabase/migrations/*.sql` 은 금지 경로 아님.
- 실제 `supabase db reset` 실행 검증은 Supabase 프로젝트가 필요한 외부 자원 의존 단계이므로, 본 PR 에서는 **SQL 구문 정확성**까지만 보증. 플랜 task-3 이 생성하는 Supabase 프로젝트가 준비된 시점에 `supabase db reset` 으로 최종 검증 예정.

## 체크리스트

- [x] 제목이 Conventional Commits 형식 (`feat(db): wave-2 — ...`)
- [x] 제목·본문 한글
- [x] 원자적 범위 (Wave 2 초기 DB 구축 한 가지 논리 단위)
- [x] `pnpm typecheck`/`lint`/`format:check`/`test:coverage` 통과
- [x] `any`, `@ts-ignore`, non-null `!` 없음 (SQL 만)
- [x] PII / 시크릿 없음
- [x] 금지된 내부 문서 포함 없음
- [x] Closes #8 #9 #10 #11

## 관련

- 플랜: `.sisyphus/plans/momentlog-mvp.md` Wave 2 (Tasks 7–10)
- 이슈: #8, #9, #10, #11
- 후속 의존: `task-11` (signed upload URL Edge Function) 이 이 버킷·RLS·트리거 위에서 동작합니다.