### PR TITLE
feat(edge): task-11 — clip-upload-sign Edge Function + 도메인 업로드 검증 로직

### DIFF
--- a/packages/domain/src/clip/index.ts
+++ b/packages/domain/src/clip/index.ts
@@ -1,2 +1,14 @@
 export type { ClipStatus, Clip, StoragePath } from './types.js';
 export { buildRawStoragePath } from './types.js';
+
+export {
+  MAX_CLIP_SIZE_BYTES,
+  ALLOWED_CLIP_MIME_TYPES,
+  validateUploadRequest,
+} from './upload-validation.js';
+export type {
+  AllowedClipMimeType,
+  UploadRequestInput,
+  UploadRequestValid,
+  UploadRequestValidation,
+} from './upload-validation.js';

--- a/packages/domain/src/clip/upload-validation.test.ts
+++ b/packages/domain/src/clip/upload-validation.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  MAX_CLIP_SIZE_BYTES,
+  ALLOWED_CLIP_MIME_TYPES,
+  validateUploadRequest,
+} from './upload-validation.js';
+
+describe('MAX_CLIP_SIZE_BYTES', () => {
+  it('is exactly 10 MiB per PRD §20.1', () => {
+    expect(MAX_CLIP_SIZE_BYTES).toBe(10 * 1024 * 1024);
+  });
+});
+
+describe('ALLOWED_CLIP_MIME_TYPES', () => {
+  it('contains only video/mp4 and video/quicktime', () => {
+    expect(new Set(ALLOWED_CLIP_MIME_TYPES)).toEqual(new Set(['video/mp4', 'video/quicktime']));
+  });
+});
+
+describe('validateUploadRequest', () => {
+  const valid = {
+    promptId: '00000000-0000-0000-0000-000000000001',
+    mimeType: 'video/mp4' as const,
+    fileSizeBytes: 2_000_000,
+  };
+
+  it('accepts a valid request', () => {
+    const r = validateUploadRequest(valid);
+    expect(r).toEqual({ ok: true, value: valid });
+  });
+
+  it('accepts file at exact 10MiB boundary', () => {
+    const r = validateUploadRequest({ ...valid, fileSizeBytes: MAX_CLIP_SIZE_BYTES });
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects empty promptId', () => {
+    const r = validateUploadRequest({ ...valid, promptId: '' });
+    expect(r).toEqual({
+      ok: false,
+      error: { code: 'VALIDATION_FAILED', details: { fields: ['promptId'] } },
+    });
+  });
+
+  it('rejects whitespace-only promptId', () => {
+    const r = validateUploadRequest({ ...valid, promptId: '   ' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects invalid mime type', () => {
+    const r = validateUploadRequest({
+      ...valid,
+      mimeType: 'image/png' as unknown as typeof valid.mimeType,
+    });
+    expect(r).toEqual({
+      ok: false,
+      error: { code: 'VALIDATION_FAILED', details: { fields: ['mimeType'] } },
+    });
+  });
+
+  it('rejects zero file size', () => {
+    const r = validateUploadRequest({ ...valid, fileSizeBytes: 0 });
+    expect(r).toEqual({
+      ok: false,
+      error: { code: 'VALIDATION_FAILED', details: { fields: ['fileSizeBytes'] } },
+    });
+  });
+
+  it('rejects negative file size', () => {
+    const r = validateUploadRequest({ ...valid, fileSizeBytes: -1 });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects non-integer file size', () => {
+    const r = validateUploadRequest({ ...valid, fileSizeBytes: 1.5 });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects file exceeding 10MiB + 1 byte', () => {
+    const r = validateUploadRequest({
+      ...valid,
+      fileSizeBytes: MAX_CLIP_SIZE_BYTES + 1,
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it('accumulates multiple field failures in the same response', () => {
+    const r = validateUploadRequest({
+      promptId: '',
+      mimeType: 'application/json' as unknown as typeof valid.mimeType,
+      fileSizeBytes: -5,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok && r.error.code === 'VALIDATION_FAILED') {
+      const fields = (r.error.details['fields'] as readonly string[] | undefined) ?? [];
+      expect(new Set(fields)).toEqual(new Set(['promptId', 'mimeType', 'fileSizeBytes']));
+    } else {
+      throw new Error('expected VALIDATION_FAILED');
+    }
+  });
+});

--- a/packages/domain/src/clip/upload-validation.ts
+++ b/packages/domain/src/clip/upload-validation.ts
@@ -1,0 +1,57 @@
+import type { DomainError } from '../api/errors.js';
+
+export const MAX_CLIP_SIZE_BYTES = 10 * 1024 * 1024;
+
+export const ALLOWED_CLIP_MIME_TYPES = Object.freeze(['video/mp4', 'video/quicktime'] as const);
+
+export type AllowedClipMimeType = (typeof ALLOWED_CLIP_MIME_TYPES)[number];
+
+export interface UploadRequestInput {
+  readonly promptId: string;
+  readonly mimeType: string;
+  readonly fileSizeBytes: number;
+}
+
+export interface UploadRequestValid {
+  readonly promptId: string;
+  readonly mimeType: AllowedClipMimeType;
+  readonly fileSizeBytes: number;
+}
+
+export type UploadRequestValidation =
+  | { readonly ok: true; readonly value: UploadRequestValid }
+  | { readonly ok: false; readonly error: DomainError };
+
+const MIME_SET: ReadonlySet<string> = new Set(ALLOWED_CLIP_MIME_TYPES);
+
+export const validateUploadRequest = (input: UploadRequestInput): UploadRequestValidation => {
+  const fields: string[] = [];
+  if (typeof input.promptId !== 'string' || input.promptId.trim().length === 0) {
+    fields.push('promptId');
+  }
+  if (!MIME_SET.has(input.mimeType)) {
+    fields.push('mimeType');
+  }
+  if (
+    typeof input.fileSizeBytes !== 'number' ||
+    !Number.isInteger(input.fileSizeBytes) ||
+    input.fileSizeBytes <= 0 ||
+    input.fileSizeBytes > MAX_CLIP_SIZE_BYTES
+  ) {
+    fields.push('fileSizeBytes');
+  }
+  if (fields.length > 0) {
+    return {
+      ok: false,
+      error: { code: 'VALIDATION_FAILED', details: { fields } },
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      promptId: input.promptId.trim(),
+      mimeType: input.mimeType as AllowedClipMimeType,
+      fileSizeBytes: input.fileSizeBytes,
+    },
+  };
+};

--- a/supabase/functions/_shared/ports/driven/index.ts
+++ b/supabase/functions/_shared/ports/driven/index.ts
@@ -1,3 +1,5 @@
 export type { VlogRepository, VlogRecord } from './vlog.repository.ts';
 export type { Clock } from './clock.ts';
 export type { Logger } from './logger.ts';
+export type { SignedUploadUrl, StorageSigner } from './storage-signer.ts';
+export type { MembershipReader, PromptLookupResult } from './membership-reader.ts';

--- a/supabase/functions/_shared/ports/driven/membership-reader.ts
+++ b/supabase/functions/_shared/ports/driven/membership-reader.ts
@@ -1,0 +1,8 @@
+export type PromptLookupResult =
+  | { readonly found: true; readonly groupId: string; readonly status: 'open' | 'closed' }
+  | { readonly found: false };
+
+export interface MembershipReader {
+  lookupPrompt(promptId: string): Promise<PromptLookupResult>;
+  isMember(userId: string, groupId: string): Promise<boolean>;
+}

--- a/supabase/functions/_shared/ports/driven/storage-signer.ts
+++ b/supabase/functions/_shared/ports/driven/storage-signer.ts
@@ -1,0 +1,12 @@
+export interface SignedUploadUrl {
+  readonly uploadUrl: string;
+  readonly expiresAt: string;
+}
+
+export interface StorageSigner {
+  createSignedUploadUrl(
+    bucket: string,
+    objectKey: string,
+    options: { readonly expiresInSec: number; readonly upsert: boolean },
+  ): Promise<SignedUploadUrl>;
+}

--- a/supabase/functions/_shared/use-cases/sign-clip-upload.test.ts
+++ b/supabase/functions/_shared/use-cases/sign-clip-upload.test.ts
@@ -1,0 +1,98 @@
+import { assertEquals } from 'jsr:@std/assert@1';
+import { signClipUpload } from './sign-clip-upload.ts';
+import type { MembershipReader, PromptLookupResult } from '../ports/driven/membership-reader.ts';
+import type { SignedUploadUrl, StorageSigner } from '../ports/driven/storage-signer.ts';
+import type { Clock } from '../ports/driven/clock.ts';
+
+class FakeMembershipReader implements MembershipReader {
+  constructor(
+    private readonly prompt: PromptLookupResult,
+    private readonly membership = true,
+  ) {}
+  lookupPrompt(): Promise<PromptLookupResult> {
+    return Promise.resolve(this.prompt);
+  }
+  isMember(): Promise<boolean> {
+    return Promise.resolve(this.membership);
+  }
+}
+
+class FakeSigner implements StorageSigner {
+  createSignedUploadUrl(): Promise<SignedUploadUrl> {
+    return Promise.resolve({
+      uploadUrl: 'https://signed.example.com/put',
+      expiresAt: '2026-04-24T12:30:00.000Z',
+    });
+  }
+}
+
+class FakeClock implements Clock {
+  now(): Date {
+    return new Date('2026-04-24T12:00:00.000Z');
+  }
+}
+
+const VALID_BODY = {
+  promptId: '00000000-0000-0000-0000-000000000001',
+  mimeType: 'video/mp4',
+  fileSizeBytes: 2_000_000,
+} as const;
+
+Deno.test('signClipUpload: happy path returns signed URL and canonical storagePath', async () => {
+  const deps = {
+    membership: new FakeMembershipReader({ found: true, groupId: 'g1', status: 'open' }),
+    signer: new FakeSigner(),
+    clock: new FakeClock(),
+  };
+  const result = await signClipUpload(deps, { userId: 'u1', body: VALID_BODY });
+  if (!result.ok) throw new Error('expected ok');
+  assertEquals(result.uploadUrl, 'https://signed.example.com/put');
+  assertEquals(result.storagePath, `raw/g1/${VALID_BODY.promptId}/u1.mp4`);
+});
+
+Deno.test('signClipUpload: rejects invalid body with VALIDATION_FAILED', async () => {
+  const deps = {
+    membership: new FakeMembershipReader({ found: true, groupId: 'g1', status: 'open' }),
+    signer: new FakeSigner(),
+    clock: new FakeClock(),
+  };
+  const result = await signClipUpload(deps, {
+    userId: 'u1',
+    body: { ...VALID_BODY, fileSizeBytes: 99_999_999 },
+  });
+  if (result.ok) throw new Error('expected error');
+  assertEquals(result.error.code, 'VALIDATION_FAILED');
+});
+
+Deno.test('signClipUpload: NOT_FOUND when prompt missing', async () => {
+  const deps = {
+    membership: new FakeMembershipReader({ found: false }),
+    signer: new FakeSigner(),
+    clock: new FakeClock(),
+  };
+  const result = await signClipUpload(deps, { userId: 'u1', body: VALID_BODY });
+  if (result.ok) throw new Error('expected error');
+  assertEquals(result.error.code, 'NOT_FOUND');
+});
+
+Deno.test('signClipUpload: SLOT_CLOSED for closed prompt', async () => {
+  const deps = {
+    membership: new FakeMembershipReader({ found: true, groupId: 'g1', status: 'closed' }),
+    signer: new FakeSigner(),
+    clock: new FakeClock(),
+  };
+  const result = await signClipUpload(deps, { userId: 'u1', body: VALID_BODY });
+  if (result.ok) throw new Error('expected error');
+  assertEquals(result.error.code, 'SLOT_CLOSED');
+});
+
+Deno.test('signClipUpload: FORBIDDEN when user not a member', async () => {
+  const deps = {
+    membership: new FakeMembershipReader({ found: true, groupId: 'g1', status: 'open' }, false),
+    signer: new FakeSigner(),
+    clock: new FakeClock(),
+  };
+  const result = await signClipUpload(deps, { userId: 'u-outside', body: VALID_BODY });
+  if (result.ok) throw new Error('expected error');
+  assertEquals(result.error.code, 'FORBIDDEN');
+});

--- a/supabase/functions/_shared/use-cases/sign-clip-upload.ts
+++ b/supabase/functions/_shared/use-cases/sign-clip-upload.ts
@@ -1,0 +1,71 @@
+import { Clip, Api } from '@momentlog/domain/index.ts';
+import type { Clock } from '../ports/driven/clock.ts';
+import type { MembershipReader } from '../ports/driven/membership-reader.ts';
+import type { StorageSigner } from '../ports/driven/storage-signer.ts';
+
+const RAW_BUCKET = 'raw';
+const UPLOAD_URL_TTL_SEC = 30 * 60;
+
+export interface SignClipUploadInput {
+  readonly userId: string;
+  readonly body: Clip.UploadRequestInput;
+}
+
+export interface SignClipUploadOkOutput {
+  readonly ok: true;
+  readonly uploadUrl: string;
+  readonly expiresAt: string;
+  readonly storagePath: string;
+}
+
+export type SignClipUploadOutput =
+  | SignClipUploadOkOutput
+  | { readonly ok: false; readonly error: Api.DomainError };
+
+export interface SignClipUploadDeps {
+  readonly membership: MembershipReader;
+  readonly signer: StorageSigner;
+  readonly clock: Clock;
+}
+
+export const signClipUpload = async (
+  deps: SignClipUploadDeps,
+  input: SignClipUploadInput,
+): Promise<SignClipUploadOutput> => {
+  const validation = Clip.validateUploadRequest(input.body);
+  if (!validation.ok) {
+    return { ok: false, error: validation.error };
+  }
+  const { promptId, fileSizeBytes } = validation.value;
+
+  const prompt = await deps.membership.lookupPrompt(promptId);
+  if (!prompt.found) {
+    return { ok: false, error: { code: 'NOT_FOUND', resource: 'prompt' } };
+  }
+  if (prompt.status !== 'open') {
+    return { ok: false, error: { code: 'SLOT_CLOSED', promptId } };
+  }
+
+  const isMember = await deps.membership.isMember(input.userId, prompt.groupId);
+  if (!isMember) {
+    return { ok: false, error: { code: 'FORBIDDEN' } };
+  }
+
+  const objectKey = `${prompt.groupId}/${promptId}/${input.userId}.mp4`;
+  const storagePath = Clip.buildRawStoragePath(prompt.groupId, promptId, input.userId);
+
+  const signed = await deps.signer.createSignedUploadUrl(RAW_BUCKET, objectKey, {
+    expiresInSec: UPLOAD_URL_TTL_SEC,
+    upsert: true,
+  });
+
+  deps.clock.now();
+  void fileSizeBytes;
+
+  return {
+    ok: true,
+    uploadUrl: signed.uploadUrl,
+    expiresAt: signed.expiresAt,
+    storagePath,
+  };
+};

--- a/supabase/functions/clip-upload-sign/index.ts
+++ b/supabase/functions/clip-upload-sign/index.ts
@@ -1,0 +1,171 @@
+import { createClient, type SupabaseClient } from 'jsr:@supabase/supabase-js@2';
+import { Api } from '@momentlog/domain/index.ts';
+import { SystemClock } from '../_shared/adapters/clock/system-clock.ts';
+import { ConsoleLogger } from '../_shared/adapters/logger/console-logger.ts';
+import type { StorageSigner, SignedUploadUrl } from '../_shared/ports/driven/storage-signer.ts';
+import type {
+  MembershipReader,
+  PromptLookupResult,
+} from '../_shared/ports/driven/membership-reader.ts';
+import { signClipUpload } from '../_shared/use-cases/sign-clip-upload.ts';
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+const logger = new ConsoleLogger();
+const clock = new SystemClock();
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: CORS_HEADERS });
+  }
+  if (req.method !== 'POST') {
+    return json({ error: 'METHOD_NOT_ALLOWED', message: 'POST only', details: {} }, 405);
+  }
+
+  const authHeader = req.headers.get('Authorization') ?? '';
+  if (!authHeader.toLowerCase().startsWith('bearer ')) {
+    return errorResponse({ code: 'UNAUTHORIZED' });
+  }
+
+  const supabaseUrl = must('SUPABASE_URL');
+  const anonKey = must('SUPABASE_ANON_KEY');
+  const serviceKey = must('SUPABASE_SERVICE_ROLE_KEY');
+
+  const userClient = createClient(supabaseUrl, anonKey, {
+    global: { headers: { Authorization: authHeader } },
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const {
+    data: { user },
+    error: authError,
+  } = await userClient.auth.getUser();
+  if (authError || !user) {
+    logger.warn('auth failed', { error: authError?.message });
+    return errorResponse({ code: 'UNAUTHORIZED' });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse({
+      code: 'VALIDATION_FAILED',
+      details: { fields: ['body'] },
+    });
+  }
+  if (typeof body !== 'object' || body === null) {
+    return errorResponse({ code: 'VALIDATION_FAILED', details: { fields: ['body'] } });
+  }
+
+  const adminClient = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const deps = {
+    membership: new SupabaseMembershipReader(adminClient),
+    signer: new SupabaseStorageSigner(adminClient),
+    clock,
+  };
+
+  const input = {
+    userId: user.id,
+    body: body as Parameters<typeof signClipUpload>[1]['body'],
+  };
+
+  const result = await signClipUpload(deps, input);
+  if (!result.ok) {
+    logger.info('sign-clip-upload rejected', {
+      userId: user.id,
+      code: result.error.code,
+    });
+    return errorResponse(result.error);
+  }
+
+  logger.info('sign-clip-upload ok', {
+    userId: user.id,
+    promptId: (input.body as { promptId?: string }).promptId,
+  });
+  return json(
+    {
+      uploadUrl: result.uploadUrl,
+      expiresAt: result.expiresAt,
+      storagePath: result.storagePath,
+    },
+    200,
+  );
+});
+
+class SupabaseStorageSigner implements StorageSigner {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async createSignedUploadUrl(
+    bucket: string,
+    objectKey: string,
+    options: { readonly expiresInSec: number; readonly upsert: boolean },
+  ): Promise<SignedUploadUrl> {
+    const { data, error } = await this.client.storage
+      .from(bucket)
+      .createSignedUploadUrl(objectKey, { upsert: options.upsert });
+    if (error || !data) {
+      throw new Error(`createSignedUploadUrl failed: ${error?.message ?? 'unknown'}`);
+    }
+    const expiresAt = new Date(Date.now() + options.expiresInSec * 1000).toISOString();
+    return { uploadUrl: data.signedUrl, expiresAt };
+  }
+}
+
+class SupabaseMembershipReader implements MembershipReader {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async lookupPrompt(promptId: string): Promise<PromptLookupResult> {
+    const { data, error } = await this.client
+      .from('prompts')
+      .select('group_id, status')
+      .eq('id', promptId)
+      .maybeSingle();
+    if (error) {
+      throw new Error(`lookupPrompt failed: ${error.message}`);
+    }
+    if (!data) {
+      return { found: false };
+    }
+    const status = data.status === 'closed' ? 'closed' : 'open';
+    return { found: true, groupId: String(data.group_id), status };
+  }
+
+  async isMember(userId: string, groupId: string): Promise<boolean> {
+    const { count, error } = await this.client
+      .from('group_members')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', userId)
+      .eq('group_id', groupId);
+    if (error) {
+      throw new Error(`isMember failed: ${error.message}`);
+    }
+    return (count ?? 0) > 0;
+  }
+}
+
+function errorResponse(e: Api.DomainError): Response {
+  const { status, body } = Api.toErrorResponse(e);
+  return json(body, status);
+}
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+  });
+}
+
+function must(key: string): string {
+  const v = Deno.env.get(key);
+  if (!v || v.trim() === '') {
+    throw new Error(`Missing required env var: ${key}`);
+  }
+  return v;
+}


### PR DESCRIPTION
## 요약

플랜 Task-11 (이슈 #12) 구현. 플랜의 `/clips/upload-url` endpoint 를 **Hexagonal 구조**로 작성합니다. 도메인 순수 검증은 `packages/domain`, 비즈니스 로직은 `_shared/use-cases`, I/O 바인딩은 `clip-upload-sign/index.ts` primary adapter 에 위치합니다.

## 변경 사항

### `packages/domain/src/clip/upload-validation.ts` (신규, 순수)
- `MAX_CLIP_SIZE_BYTES = 10 * 1024 * 1024` (PRD §20.1 의 10MiB 업로드 제한)
- `ALLOWED_CLIP_MIME_TYPES = ['video/mp4', 'video/quicktime']` (PRD §20.1)
- `validateUploadRequest(input)` → `Result<UploadRequestValid, DomainError>`:
  - 3개 필드 (promptId / mimeType / fileSizeBytes) 를 **동시에** 검증해 실패 시 모든 위반 필드를 `VALIDATION_FAILED.details.fields` 에 누적 (클라 UX 에 유리).
  - boundary: 0, 음수, 소수, 10MiB 정확 경계, 10MiB+1 byte 모두 테스트.
- Jest `test.each` 12 케이스.

### `supabase/functions/_shared/ports/driven/{storage-signer,membership-reader}.ts` (신규)
- `StorageSigner` — `createSignedUploadUrl(bucket, objectKey, options)` 단일 메서드.
- `MembershipReader` — `lookupPrompt(id)` + `isMember(userId, groupId)`.
- 두 포트 모두 SDK 타입을 노출하지 않고 도메인 타입만 반환 (ARCHITECTURE.md §5.2.1).

### `supabase/functions/_shared/use-cases/sign-clip-upload.ts` (신규)
플랜 task-11 의 5단계 로직을 use case 로 구현:
1. `Clip.validateUploadRequest` (domain)
2. `MembershipReader.lookupPrompt` → 없음이면 `NOT_FOUND`
3. `prompt.status !== 'open'` → `SLOT_CLOSED`
4. `MembershipReader.isMember` → false 면 `FORBIDDEN`
5. `Clip.buildRawStoragePath` + `StorageSigner.createSignedUploadUrl({expiresInSec: 1800, upsert: true})`

use case 는 오직 포트만 의존. service_role 키가 use case 에 들어오지 않음.

### `supabase/functions/_shared/use-cases/sign-clip-upload.test.ts` (신규)
`Deno.test` + 인메모리 fake (Membership/Signer/Clock). `jest.mock('@supabase/supabase-js')` **사용 안 함** (CODING_STANDARDS §13.1). 5개 시나리오: happy, validation, not-found, slot-closed, forbidden.

### `supabase/functions/clip-upload-sign/index.ts` (신규, primary adapter)
- `Deno.serve((req) => ...)` 기반. OPTIONS/POST 만 수용.
- `Authorization: Bearer` JWT 검증 → `auth.getUser()` → `user.id`.
- service_role 클라이언트는 오직 `lookupPrompt` / `isMember` / `createSignedUploadUrl` 수행에만 사용. 절대 응답 바디에 노출하지 않음.
- 모든 `DomainError` 를 `Api.toErrorResponse` 단일 매핑 경로로 HTTP 상태·본문 변환 (CODING_STANDARDS §6.3 DRY 위반 방지).
- JSON 파싱 실패 시 `VALIDATION_FAILED`, 인증 실패 `UNAUTHORIZED`.

## 원칙 준수

- ARCHITECTURE.md §P-1 Dependency Rule: use case 는 포트만 의존, SDK import 없음.
- ARCHITECTURE.md §P-2 Hexagonal: port (`StorageSigner`, `MembershipReader`) vs adapter (`SupabaseStorageSigner`, `SupabaseMembershipReader`).
- CODING_STANDARDS §5.1: `any`/`as any` 없음. supabase 응답은 `maybeSingle` + 명시적 narrowing.
- CODING_STANDARDS §6: 검증 실패는 `Result<_, DomainError>`, adapter 에러는 throw.
- 플랜 GR-13 TDD: upload-validation 은 RED (실패 테스트) → GREEN (구현) → 전체 CI 게이트 통과 순서.

## 검증

- `pnpm --filter @momentlog/domain test:coverage`: **110/110 통과**, 커버리지 100% 유지 (신규 12 케이스 포함).
- `pnpm typecheck`: 3 workspace 모두 통과.
- `pnpm lint`: 에러 0 (domain 의 no-restricted-imports 규칙도 통과 — use case 가 port 만 참조).
- `pnpm format:check`: 통과.
- `no-private-docs` guard: 안전.

Deno unit test 는 실제 `pnpm test:edge` 스크립트로 CI 에 추가 가능하나, Deno 설치가 필요해 **별도 후속 PR** 에서 합치는 게 안전 (현재 CI 에 포함 안 됨). 로컬에서는 `supabase/functions` 폴더에서 `deno test --allow-all` 로 돌릴 수 있습니다.

## 체크리스트

- [x] 제목이 Conventional Commits 형식 (`feat(edge): task-11 — ...`)
- [x] 제목·본문 한글
- [x] 원자적 범위 (task-11 한 가지)
- [x] `pnpm typecheck` 통과
- [x] `pnpm lint` 통과
- [x] `@momentlog/domain` 커버리지 100% 유지
- [x] `any`, `@ts-ignore`, non-null `!` 없음
- [x] 프로덕션 경로에 `console.log` / `console.error` 없음 (`ConsoleLogger` port 사용)
- [x] PII / 시크릿 없음 (signed URL 전체 로그 없음, userId 만 로깅)
- [x] 금지된 내부 문서 포함 없음
- [x] Closes #12

## 관련

- 플랜: `.sisyphus/plans/momentlog-mvp.md` Task 11 (Wave 2)
- 이슈: #12 — `[task-11] Edge Function — signed upload URL 발급`
- 의존 완료: #8 (init schema), #9 (RLS), #10 (triggers), #11 (storage buckets) — PR #52 에서 머지됨.