### PR TITLE
feat(edge): wave-3 서버측 — groups-create + invites-accept Edge Functions 도입

### DIFF
--- a/packages/domain/src/group/create-validation.test.ts
+++ b/packages/domain/src/group/create-validation.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from '@jest/globals';
+import { validateCreateGroupInput } from './create-validation.js';
+
+describe('validateCreateGroupInput', () => {
+  const valid = {
+    name: '우리둘',
+    timezone: 'Asia/Seoul',
+    activeHourStart: 9,
+    activeHourEnd: 22,
+  };
+
+  it('accepts a valid input', () => {
+    const r = validateCreateGroupInput(valid);
+    expect(r).toEqual({ ok: true, value: valid });
+  });
+
+  it('trims name whitespace', () => {
+    const r = validateCreateGroupInput({ ...valid, name: '  trimmed  ' });
+    if (!r.ok) throw new Error('expected ok');
+    expect(r.value.name).toBe('trimmed');
+  });
+
+  it('rejects name that is empty after trim', () => {
+    const r = validateCreateGroupInput({ ...valid, name: '   ' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects non-string name', () => {
+    const r = validateCreateGroupInput({
+      ...valid,
+      name: 42 as unknown as string,
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects name longer than 40 chars', () => {
+    const r = validateCreateGroupInput({ ...valid, name: 'a'.repeat(41) });
+    expect(r.ok).toBe(false);
+  });
+
+  it('accepts 40-char name exactly', () => {
+    const r = validateCreateGroupInput({ ...valid, name: 'a'.repeat(40) });
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects non-IANA timezone (missing slash)', () => {
+    const r = validateCreateGroupInput({ ...valid, timezone: 'Seoul' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects timezone with whitespace', () => {
+    const r = validateCreateGroupInput({ ...valid, timezone: 'Asia / Seoul' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects non-string timezone', () => {
+    const r = validateCreateGroupInput({
+      ...valid,
+      timezone: 42 as unknown as string,
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects timezone with invalid characters in regex (e.g. starts with digit)', () => {
+    const r = validateCreateGroupInput({ ...valid, timezone: '9Asia/Seoul' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('accepts common IANA timezones', () => {
+    for (const tz of ['Asia/Seoul', 'Asia/Tokyo', 'America/Los_Angeles', 'Europe/Berlin']) {
+      const r = validateCreateGroupInput({ ...valid, timezone: tz });
+      expect(r.ok).toBe(true);
+    }
+  });
+
+  it('rejects activeHourStart out of 0..23', () => {
+    expect(validateCreateGroupInput({ ...valid, activeHourStart: -1 }).ok).toBe(false);
+    expect(validateCreateGroupInput({ ...valid, activeHourStart: 24 }).ok).toBe(false);
+  });
+
+  it('rejects activeHourEnd out of 0..23', () => {
+    expect(validateCreateGroupInput({ ...valid, activeHourEnd: -1 }).ok).toBe(false);
+    expect(validateCreateGroupInput({ ...valid, activeHourEnd: 24 }).ok).toBe(false);
+  });
+
+  it('rejects when start >= end', () => {
+    expect(validateCreateGroupInput({ ...valid, activeHourStart: 12, activeHourEnd: 12 }).ok).toBe(
+      false,
+    );
+    expect(validateCreateGroupInput({ ...valid, activeHourStart: 22, activeHourEnd: 9 }).ok).toBe(
+      false,
+    );
+  });
+
+  it('rejects non-integer hours', () => {
+    expect(validateCreateGroupInput({ ...valid, activeHourStart: 9.5 }).ok).toBe(false);
+    expect(validateCreateGroupInput({ ...valid, activeHourEnd: 22.5 }).ok).toBe(false);
+  });
+
+  it('accumulates failing fields', () => {
+    const r = validateCreateGroupInput({
+      name: '',
+      timezone: 'invalid',
+      activeHourStart: 30,
+      activeHourEnd: 40,
+    });
+    if (r.ok || r.error.code !== 'VALIDATION_FAILED') {
+      throw new Error('expected VALIDATION_FAILED');
+    }
+    const fields = r.error.details['fields'] as readonly string[];
+    expect(new Set(fields)).toEqual(
+      new Set(['name', 'timezone', 'activeHourStart', 'activeHourEnd']),
+    );
+  });
+});

--- a/packages/domain/src/group/create-validation.ts
+++ b/packages/domain/src/group/create-validation.ts
@@ -1,0 +1,59 @@
+import type { DomainError } from '../api/errors.js';
+
+export interface CreateGroupInput {
+  readonly name: string;
+  readonly timezone: string;
+  readonly activeHourStart: number;
+  readonly activeHourEnd: number;
+}
+
+export type CreateGroupValidation =
+  | { readonly ok: true; readonly value: CreateGroupInput }
+  | { readonly ok: false; readonly error: DomainError };
+
+const NAME_MAX = 40;
+
+const isIanaTimezone = (tz: string): boolean => {
+  if (typeof tz !== 'string') return false;
+  if (!tz.includes('/')) return false;
+  if (/\s/.test(tz)) return false;
+  return /^[A-Za-z][A-Za-z0-9_+-]*\/[A-Za-z][A-Za-z0-9_+-]*(\/[A-Za-z][A-Za-z0-9_+-]*)?$/.test(tz);
+};
+
+const isValidHour = (h: unknown): h is number =>
+  typeof h === 'number' && Number.isInteger(h) && h >= 0 && h <= 23;
+
+export const validateCreateGroupInput = (input: CreateGroupInput): CreateGroupValidation => {
+  const fields: string[] = [];
+  const name = typeof input.name === 'string' ? input.name.trim() : '';
+  if (name.length === 0 || name.length > NAME_MAX) {
+    fields.push('name');
+  }
+  if (!isIanaTimezone(input.timezone)) {
+    fields.push('timezone');
+  }
+  if (!isValidHour(input.activeHourStart)) {
+    fields.push('activeHourStart');
+  }
+  if (!isValidHour(input.activeHourEnd)) {
+    fields.push('activeHourEnd');
+  }
+  if (fields.length === 0 && input.activeHourStart >= input.activeHourEnd) {
+    fields.push('activeHourStart', 'activeHourEnd');
+  }
+  if (fields.length > 0) {
+    return {
+      ok: false,
+      error: { code: 'VALIDATION_FAILED', details: { fields: Array.from(new Set(fields)) } },
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      name,
+      timezone: input.timezone,
+      activeHourStart: input.activeHourStart,
+      activeHourEnd: input.activeHourEnd,
+    },
+  };
+};

--- a/packages/domain/src/group/index.ts
+++ b/packages/domain/src/group/index.ts
@@ -1,1 +1,30 @@
 export type { GroupMemberRole, Group, GroupMember } from './types.js';
+
+export {
+  INVITE_CODE_ALPHABET,
+  INVITE_CODE_LENGTH,
+  INVITE_TTL_MS,
+  generateInviteCode,
+  isValidInviteCode,
+} from './invite-code.js';
+export type { RandomBytesFn } from './invite-code.js';
+
+export { validateCreateGroupInput } from './create-validation.js';
+export type { CreateGroupInput, CreateGroupValidation } from './create-validation.js';
+
+export {
+  RATE_LIMIT_WINDOW_MS,
+  RATE_LIMIT_MAX,
+  FAIL_BLOCK_WINDOW_MS,
+  FAIL_BLOCK_THRESHOLD,
+  FAIL_BLOCK_DURATION_MS,
+  evaluateInviteRateLimit,
+} from './invite-rate-limit.js';
+export type {
+  InviteAttempt,
+  EvaluateInviteRateLimitInput,
+  RateLimitDecision,
+} from './invite-rate-limit.js';
+
+export { MAX_GROUP_MEMBERS, canAddMember } from './membership-limit.js';
+export type { CanAddMemberInput, CanAddMemberResult } from './membership-limit.js';

--- a/packages/domain/src/group/invite-code.test.ts
+++ b/packages/domain/src/group/invite-code.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  INVITE_CODE_ALPHABET,
+  INVITE_CODE_LENGTH,
+  INVITE_TTL_MS,
+  generateInviteCode,
+  isValidInviteCode,
+} from './invite-code.js';
+
+describe('invite code constants', () => {
+  it('INVITE_CODE_LENGTH = 8', () => {
+    expect(INVITE_CODE_LENGTH).toBe(8);
+  });
+
+  it('INVITE_TTL_MS = 24h', () => {
+    expect(INVITE_TTL_MS).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it('INVITE_CODE_ALPHABET excludes confusing chars 0/O/1/I/L', () => {
+    const chars = [...INVITE_CODE_ALPHABET];
+    expect(chars).not.toContain('0');
+    expect(chars).not.toContain('O');
+    expect(chars).not.toContain('1');
+    expect(chars).not.toContain('I');
+    expect(chars).not.toContain('L');
+    expect(chars).not.toContain('l');
+    for (const c of chars) {
+      expect(/[A-Z2-9]/.test(c)).toBe(true);
+    }
+  });
+
+  it('INVITE_CODE_ALPHABET has unique characters only', () => {
+    expect(new Set(INVITE_CODE_ALPHABET).size).toBe(INVITE_CODE_ALPHABET.length);
+  });
+});
+
+describe('generateInviteCode', () => {
+  it('produces a code of exactly INVITE_CODE_LENGTH using only the allowed alphabet', () => {
+    const randomBytes = (n: number) => new Uint8Array(n).map((_, i) => (i * 17 + 3) & 0xff);
+    const code = generateInviteCode(randomBytes);
+    expect(code).toHaveLength(INVITE_CODE_LENGTH);
+    for (const c of code) {
+      expect(INVITE_CODE_ALPHABET).toContain(c);
+    }
+  });
+
+  it('is deterministic for a given randomBytes source', () => {
+    const rb = (n: number) => new Uint8Array(n).map((_, i) => (i * 5 + 1) & 0xff);
+    expect(generateInviteCode(rb)).toBe(generateInviteCode(rb));
+  });
+
+  it('produces different outputs for different byte sources', () => {
+    const a = generateInviteCode((n) => new Uint8Array(n).map((_, i) => i));
+    const b = generateInviteCode((n) => new Uint8Array(n).map((_, i) => i + 128));
+    expect(a).not.toBe(b);
+  });
+
+  it('throws when randomBytes returns too few bytes', () => {
+    const broken = () => new Uint8Array(3);
+    expect(() => generateInviteCode(broken)).toThrow(/randomBytes/i);
+  });
+});
+
+describe('isValidInviteCode', () => {
+  it('accepts well-formed 8-char alphabet codes', () => {
+    expect(isValidInviteCode('ABCD2345')).toBe(true);
+    expect(isValidInviteCode('ZZZZ9999')).toBe(true);
+  });
+
+  it('rejects wrong length', () => {
+    expect(isValidInviteCode('ABCD234')).toBe(false);
+    expect(isValidInviteCode('ABCD23456')).toBe(false);
+    expect(isValidInviteCode('')).toBe(false);
+  });
+
+  it('rejects confusing characters', () => {
+    expect(isValidInviteCode('ABCD2340')).toBe(false);
+    expect(isValidInviteCode('ABCD234O')).toBe(false);
+    expect(isValidInviteCode('ABCD2341')).toBe(false);
+    expect(isValidInviteCode('ABCD234I')).toBe(false);
+    expect(isValidInviteCode('ABCD234L')).toBe(false);
+  });
+
+  it('rejects lowercase and symbols', () => {
+    expect(isValidInviteCode('abcd2345')).toBe(false);
+    expect(isValidInviteCode('ABCD-345')).toBe(false);
+    expect(isValidInviteCode('ABCD 345')).toBe(false);
+  });
+
+  it('rejects non-string input', () => {
+    expect(isValidInviteCode(null as unknown as string)).toBe(false);
+    expect(isValidInviteCode(undefined as unknown as string)).toBe(false);
+    expect(isValidInviteCode(12345678 as unknown as string)).toBe(false);
+  });
+});

--- a/packages/domain/src/group/invite-code.ts
+++ b/packages/domain/src/group/invite-code.ts
@@ -1,0 +1,34 @@
+export const INVITE_CODE_LENGTH = 8;
+export const INVITE_TTL_MS = 24 * 60 * 60 * 1000;
+
+const BASE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+export const INVITE_CODE_ALPHABET = BASE_ALPHABET;
+
+const ALPHABET_SET: ReadonlySet<string> = new Set(INVITE_CODE_ALPHABET);
+
+export type RandomBytesFn = (length: number) => Uint8Array;
+
+export const generateInviteCode = (randomBytes: RandomBytesFn): string => {
+  const bytes = randomBytes(INVITE_CODE_LENGTH);
+  if (!(bytes instanceof Uint8Array) || bytes.length < INVITE_CODE_LENGTH) {
+    throw new Error(
+      `randomBytes must return at least ${INVITE_CODE_LENGTH} bytes; got ${bytes.length}`,
+    );
+  }
+  const base = INVITE_CODE_ALPHABET.length;
+  let code = '';
+  for (let i = 0; i < INVITE_CODE_LENGTH; i++) {
+    const idx = (bytes[i] as number) % base;
+    code += INVITE_CODE_ALPHABET[idx];
+  }
+  return code;
+};
+
+export const isValidInviteCode = (code: string): boolean => {
+  if (typeof code !== 'string') return false;
+  if (code.length !== INVITE_CODE_LENGTH) return false;
+  for (const c of code) {
+    if (!ALPHABET_SET.has(c)) return false;
+  }
+  return true;
+};

--- a/packages/domain/src/group/invite-rate-limit.test.ts
+++ b/packages/domain/src/group/invite-rate-limit.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  RATE_LIMIT_WINDOW_MS,
+  RATE_LIMIT_MAX,
+  FAIL_BLOCK_WINDOW_MS,
+  FAIL_BLOCK_THRESHOLD,
+  FAIL_BLOCK_DURATION_MS,
+  evaluateInviteRateLimit,
+  type InviteAttempt,
+} from './invite-rate-limit.js';
+
+const NOW = new Date('2026-04-24T12:00:00.000Z');
+
+const secondsBefore = (seconds: number): string =>
+  new Date(NOW.getTime() - seconds * 1000).toISOString();
+
+describe('rate limit constants (PRD §8.8)', () => {
+  it('hourly window = 3600000ms, max 10', () => {
+    expect(RATE_LIMIT_WINDOW_MS).toBe(60 * 60 * 1000);
+    expect(RATE_LIMIT_MAX).toBe(10);
+  });
+
+  it('fail-block threshold = 5 failures in 15 min, block 15 min', () => {
+    expect(FAIL_BLOCK_WINDOW_MS).toBe(15 * 60 * 1000);
+    expect(FAIL_BLOCK_THRESHOLD).toBe(5);
+    expect(FAIL_BLOCK_DURATION_MS).toBe(15 * 60 * 1000);
+  });
+});
+
+describe('evaluateInviteRateLimit', () => {
+  it('allows a fresh IP with no attempts', () => {
+    const r = evaluateInviteRateLimit({ now: NOW, attempts: [] });
+    expect(r).toEqual({ allowed: true });
+  });
+
+  it('allows 10 attempts in the last hour', () => {
+    const attempts: InviteAttempt[] = Array.from({ length: 10 }, (_, i) => ({
+      attemptedAt: secondsBefore((i + 1) * 100),
+      success: true,
+    }));
+    const r = evaluateInviteRateLimit({ now: NOW, attempts });
+    expect(r.allowed).toBe(true);
+  });
+
+  it('blocks the 11th attempt within the hour', () => {
+    const attempts: InviteAttempt[] = Array.from({ length: 11 }, (_, i) => ({
+      attemptedAt: secondsBefore((i + 1) * 100),
+      success: true,
+    }));
+    const r = evaluateInviteRateLimit({ now: NOW, attempts });
+    if (r.allowed) throw new Error('expected blocked');
+    expect(r.reason).toBe('RATE_LIMITED_HOURLY');
+    expect(r.retryAfterSec).toBeGreaterThan(0);
+  });
+
+  it('ignores attempts outside the hourly window', () => {
+    const attempts: InviteAttempt[] = Array.from({ length: 15 }, (_, i) => ({
+      attemptedAt: secondsBefore(3601 + i * 5),
+      success: true,
+    }));
+    const r = evaluateInviteRateLimit({ now: NOW, attempts });
+    expect(r.allowed).toBe(true);
+  });
+
+  it('blocks after 5 failures in 15 min', () => {
+    const attempts: InviteAttempt[] = Array.from({ length: 5 }, (_, i) => ({
+      attemptedAt: secondsBefore((i + 1) * 60),
+      success: false,
+    }));
+    const r = evaluateInviteRateLimit({ now: NOW, attempts });
+    if (r.allowed) throw new Error('expected blocked');
+    expect(r.reason).toBe('FAILURE_BLOCK');
+    expect(r.retryAfterSec).toBeGreaterThan(0);
+    expect(r.retryAfterSec).toBeLessThanOrEqual(FAIL_BLOCK_DURATION_MS / 1000);
+  });
+
+  it('does not trigger failure block if fewer than 5 failures', () => {
+    const attempts: InviteAttempt[] = Array.from({ length: 4 }, (_, i) => ({
+      attemptedAt: secondsBefore((i + 1) * 60),
+      success: false,
+    }));
+    const r = evaluateInviteRateLimit({ now: NOW, attempts });
+    expect(r.allowed).toBe(true);
+  });
+
+  it('does not trigger failure block for failures older than 15 minutes', () => {
+    const attempts: InviteAttempt[] = Array.from({ length: 8 }, (_, i) => ({
+      attemptedAt: secondsBefore(15 * 60 + 10 + i * 5),
+      success: false,
+    }));
+    const r = evaluateInviteRateLimit({ now: NOW, attempts });
+    expect(r.allowed).toBe(true);
+  });
+
+  it('reports earliest retryAfter between the two windows', () => {
+    const attempts: InviteAttempt[] = [
+      ...Array.from({ length: 11 }, (_, i) => ({
+        attemptedAt: secondsBefore(60 + i * 50),
+        success: true as const,
+      })),
+      ...Array.from({ length: 5 }, (_, i) => ({
+        attemptedAt: secondsBefore(10 + i * 10),
+        success: false as const,
+      })),
+    ];
+    const r = evaluateInviteRateLimit({ now: NOW, attempts });
+    if (r.allowed) throw new Error('expected blocked');
+    expect(r.retryAfterSec).toBeGreaterThan(0);
+  });
+
+  it('retryAfterSec for hourly block is bounded by 1 hour', () => {
+    const attempts: InviteAttempt[] = Array.from({ length: 11 }, (_, i) => ({
+      attemptedAt: secondsBefore(3599 - i),
+      success: true,
+    }));
+    const r = evaluateInviteRateLimit({ now: NOW, attempts });
+    if (r.allowed) throw new Error('expected blocked');
+    expect(r.retryAfterSec).toBeLessThanOrEqual(3600);
+    expect(r.retryAfterSec).toBeGreaterThanOrEqual(1);
+  });
+
+  it('throws on invalid attempt timestamp', () => {
+    expect(() =>
+      evaluateInviteRateLimit({
+        now: NOW,
+        attempts: [{ attemptedAt: 'bad', success: true }],
+      }),
+    ).toThrow(/attemptedAt/);
+  });
+});

--- a/packages/domain/src/group/invite-rate-limit.ts
+++ b/packages/domain/src/group/invite-rate-limit.ts
@@ -1,0 +1,56 @@
+export const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+export const RATE_LIMIT_MAX = 10;
+export const FAIL_BLOCK_WINDOW_MS = 15 * 60 * 1000;
+export const FAIL_BLOCK_THRESHOLD = 5;
+export const FAIL_BLOCK_DURATION_MS = 15 * 60 * 1000;
+
+export interface InviteAttempt {
+  readonly attemptedAt: string;
+  readonly success: boolean;
+}
+
+export interface EvaluateInviteRateLimitInput {
+  readonly now: Date;
+  readonly attempts: readonly InviteAttempt[];
+}
+
+export type RateLimitDecision =
+  | { readonly allowed: true }
+  | {
+      readonly allowed: false;
+      readonly reason: 'RATE_LIMITED_HOURLY' | 'FAILURE_BLOCK';
+      readonly retryAfterSec: number;
+    };
+
+export const evaluateInviteRateLimit = (input: EvaluateInviteRateLimitInput): RateLimitDecision => {
+  const nowMs = input.now.getTime();
+  const attempts = input.attempts.map((a) => {
+    const ms = Date.parse(a.attemptedAt);
+    if (Number.isNaN(ms)) {
+      throw new Error(`invalid attemptedAt: ${a.attemptedAt}`);
+    }
+    return { ms, success: a.success };
+  });
+
+  const recentFailures = attempts.filter((a) => !a.success && nowMs - a.ms <= FAIL_BLOCK_WINDOW_MS);
+  if (recentFailures.length >= FAIL_BLOCK_THRESHOLD) {
+    const newestFailureMs = Math.max(...recentFailures.map((a) => a.ms));
+    const retryAfterSec = Math.max(
+      1,
+      Math.ceil((newestFailureMs + FAIL_BLOCK_DURATION_MS - nowMs) / 1000),
+    );
+    return { allowed: false, reason: 'FAILURE_BLOCK', retryAfterSec };
+  }
+
+  const withinHour = attempts.filter((a) => nowMs - a.ms <= RATE_LIMIT_WINDOW_MS);
+  if (withinHour.length > RATE_LIMIT_MAX) {
+    const oldestInWindowMs = Math.min(...withinHour.map((a) => a.ms));
+    const retryAfterSec = Math.max(
+      1,
+      Math.ceil((oldestInWindowMs + RATE_LIMIT_WINDOW_MS - nowMs) / 1000),
+    );
+    return { allowed: false, reason: 'RATE_LIMITED_HOURLY', retryAfterSec };
+  }
+
+  return { allowed: true };
+};

--- a/packages/domain/src/group/membership-limit.test.ts
+++ b/packages/domain/src/group/membership-limit.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from '@jest/globals';
+import { MAX_GROUP_MEMBERS, canAddMember } from './membership-limit.js';
+
+describe('MAX_GROUP_MEMBERS', () => {
+  it('is exactly 4 per PRD §8.1', () => {
+    expect(MAX_GROUP_MEMBERS).toBe(4);
+  });
+});
+
+describe('canAddMember', () => {
+  it('allows when current < max', () => {
+    expect(canAddMember({ currentMemberCount: 3 })).toEqual({ ok: true });
+    expect(canAddMember({ currentMemberCount: 0 })).toEqual({ ok: true });
+  });
+
+  it('rejects when current = max', () => {
+    const r = canAddMember({ currentMemberCount: 4 });
+    if (r.ok) throw new Error('expected block');
+    expect(r.reason).toBe('GROUP_FULL');
+  });
+
+  it('rejects when current > max (already over — should not happen, but defensive)', () => {
+    const r = canAddMember({ currentMemberCount: 5 });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects on negative count', () => {
+    const r = canAddMember({ currentMemberCount: -1 });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects on non-integer count', () => {
+    const r = canAddMember({ currentMemberCount: 3.5 });
+    expect(r.ok).toBe(false);
+  });
+});

--- a/packages/domain/src/group/membership-limit.ts
+++ b/packages/domain/src/group/membership-limit.ts
@@ -1,0 +1,20 @@
+export const MAX_GROUP_MEMBERS = 4;
+
+export interface CanAddMemberInput {
+  readonly currentMemberCount: number;
+}
+
+export type CanAddMemberResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: 'GROUP_FULL' | 'INVALID_COUNT' };
+
+export const canAddMember = (input: CanAddMemberInput): CanAddMemberResult => {
+  const n = input.currentMemberCount;
+  if (typeof n !== 'number' || !Number.isInteger(n) || n < 0) {
+    return { ok: false, reason: 'INVALID_COUNT' };
+  }
+  if (n >= MAX_GROUP_MEMBERS) {
+    return { ok: false, reason: 'GROUP_FULL' };
+  }
+  return { ok: true };
+};

--- a/supabase/functions/_shared/ports/driven/group.repository.ts
+++ b/supabase/functions/_shared/ports/driven/group.repository.ts
@@ -1,0 +1,31 @@
+export interface GroupRepositoryCreateInput {
+  readonly name: string;
+  readonly ownerId: string;
+  readonly timezone: string;
+  readonly activeHourStart: number;
+  readonly activeHourEnd: number;
+  readonly inviteCode: string;
+  readonly inviteExpiresAt: string;
+}
+
+export interface GroupRepositoryCreated {
+  readonly groupId: string;
+  readonly inviteCode: string;
+  readonly inviteExpiresAt: string;
+}
+
+export type GroupCreateResult =
+  | { readonly ok: true; readonly value: GroupRepositoryCreated }
+  | { readonly ok: false; readonly reason: 'INVITE_CODE_CONFLICT' };
+
+export interface InviteCodeResolution {
+  readonly groupId: string;
+  readonly inviteExpiresAt: string;
+  readonly currentMemberCount: number;
+}
+
+export interface GroupRepository {
+  createGroupWithOwner(input: GroupRepositoryCreateInput): Promise<GroupCreateResult>;
+  resolveInviteCode(code: string): Promise<InviteCodeResolution | null>;
+  addMember(input: { readonly groupId: string; readonly userId: string }): Promise<void>;
+}

--- a/supabase/functions/_shared/ports/driven/index.ts
+++ b/supabase/functions/_shared/ports/driven/index.ts
@@ -3,3 +3,12 @@ export type { Clock } from './clock.ts';
 export type { Logger } from './logger.ts';
 export type { SignedUploadUrl, StorageSigner } from './storage-signer.ts';
 export type { MembershipReader, PromptLookupResult } from './membership-reader.ts';
+export type {
+  GroupRepository,
+  GroupRepositoryCreateInput,
+  GroupRepositoryCreated,
+  GroupCreateResult,
+  InviteCodeResolution,
+} from './group.repository.ts';
+export type { InviteAttemptRepository, RecordAttemptInput } from './invite-attempt.repository.ts';
+export type { RandomBytesPort } from './random-bytes.ts';

--- a/supabase/functions/_shared/ports/driven/invite-attempt.repository.ts
+++ b/supabase/functions/_shared/ports/driven/invite-attempt.repository.ts
@@ -1,0 +1,12 @@
+import type { InviteAttempt } from '@momentlog/domain/group/index.ts';
+
+export interface RecordAttemptInput {
+  readonly inviteCode: string;
+  readonly ipAddress: string;
+  readonly success: boolean;
+}
+
+export interface InviteAttemptRepository {
+  recentAttempts(ipAddress: string, sinceMs: number): Promise<readonly InviteAttempt[]>;
+  record(input: RecordAttemptInput): Promise<void>;
+}

--- a/supabase/functions/_shared/ports/driven/random-bytes.ts
+++ b/supabase/functions/_shared/ports/driven/random-bytes.ts
@@ -1,0 +1,3 @@
+export interface RandomBytesPort {
+  bytes(length: number): Uint8Array;
+}

--- a/supabase/functions/_shared/use-cases/accept-invite.test.ts
+++ b/supabase/functions/_shared/use-cases/accept-invite.test.ts
@@ -1,0 +1,158 @@
+import { assertEquals } from 'jsr:@std/assert@1';
+import { acceptInvite } from './accept-invite.ts';
+import type {
+  GroupCreateResult,
+  GroupRepository,
+  GroupRepositoryCreateInput,
+  InviteCodeResolution,
+} from '../ports/driven/group.repository.ts';
+import type {
+  InviteAttemptRepository,
+  RecordAttemptInput,
+} from '../ports/driven/invite-attempt.repository.ts';
+import type { InviteAttempt } from '@momentlog/domain/group/index.ts';
+import type { Clock } from '../ports/driven/clock.ts';
+
+class FakeGroupRepo implements GroupRepository {
+  addMemberCalls: { groupId: string; userId: string }[] = [];
+  constructor(private readonly resolution: InviteCodeResolution | null) {}
+  createGroupWithOwner(_: GroupRepositoryCreateInput): Promise<GroupCreateResult> {
+    return Promise.resolve({ ok: false, reason: 'INVITE_CODE_CONFLICT' });
+  }
+  resolveInviteCode(): Promise<InviteCodeResolution | null> {
+    return Promise.resolve(this.resolution);
+  }
+  addMember(input: { groupId: string; userId: string }): Promise<void> {
+    this.addMemberCalls.push(input);
+    return Promise.resolve();
+  }
+}
+
+class FakeAttempts implements InviteAttemptRepository {
+  records: RecordAttemptInput[] = [];
+  constructor(private readonly recent: readonly InviteAttempt[] = []) {}
+  recentAttempts(): Promise<readonly InviteAttempt[]> {
+    return Promise.resolve(this.recent);
+  }
+  record(input: RecordAttemptInput): Promise<void> {
+    this.records.push(input);
+    return Promise.resolve();
+  }
+}
+
+class FixedClock implements Clock {
+  now(): Date {
+    return new Date('2026-04-24T12:00:00.000Z');
+  }
+}
+
+const VALID_CODE = 'ABCD2345';
+
+Deno.test(
+  'acceptInvite: invalid code format returns INVITE_INVALID and records failure',
+  async () => {
+    const attempts = new FakeAttempts();
+    const result = await acceptInvite(
+      {
+        groupRepo: new FakeGroupRepo(null),
+        attempts,
+        clock: new FixedClock(),
+      },
+      { userId: 'u', ipAddress: '1.2.3.4', code: 'bad' },
+    );
+    if (result.ok) throw new Error('expected error');
+    assertEquals(result.error.code, 'INVITE_INVALID');
+    assertEquals(attempts.records.length, 1);
+    assertEquals(attempts.records[0]!.success, false);
+  },
+);
+
+Deno.test('acceptInvite: rate-limited IP gets INVITE_RATE_LIMITED', async () => {
+  const many: InviteAttempt[] = Array.from({ length: 12 }, (_, i) => ({
+    attemptedAt: new Date('2026-04-24T11:45:00.000Z')
+      .toISOString()
+      .replace('11:45', `11:${50 - i}`.slice(0, 5)),
+    success: true,
+  }));
+  const attempts = new FakeAttempts(many);
+  const result = await acceptInvite(
+    {
+      groupRepo: new FakeGroupRepo({
+        groupId: 'g1',
+        inviteExpiresAt: '2030-01-01T00:00:00.000Z',
+        currentMemberCount: 2,
+      }),
+      attempts,
+      clock: new FixedClock(),
+    },
+    { userId: 'u', ipAddress: '1.2.3.4', code: VALID_CODE },
+  );
+  if (result.ok) throw new Error('expected error');
+  assertEquals(result.error.code, 'INVITE_RATE_LIMITED');
+});
+
+Deno.test('acceptInvite: code not found returns INVITE_INVALID', async () => {
+  const result = await acceptInvite(
+    {
+      groupRepo: new FakeGroupRepo(null),
+      attempts: new FakeAttempts(),
+      clock: new FixedClock(),
+    },
+    { userId: 'u', ipAddress: '1.2.3.4', code: VALID_CODE },
+  );
+  if (result.ok) throw new Error('expected error');
+  assertEquals(result.error.code, 'INVITE_INVALID');
+});
+
+Deno.test('acceptInvite: expired invite returns INVITE_INVALID', async () => {
+  const result = await acceptInvite(
+    {
+      groupRepo: new FakeGroupRepo({
+        groupId: 'g1',
+        inviteExpiresAt: '2020-01-01T00:00:00.000Z',
+        currentMemberCount: 1,
+      }),
+      attempts: new FakeAttempts(),
+      clock: new FixedClock(),
+    },
+    { userId: 'u', ipAddress: '1.2.3.4', code: VALID_CODE },
+  );
+  if (result.ok) throw new Error('expected error');
+  assertEquals(result.error.code, 'INVITE_INVALID');
+});
+
+Deno.test('acceptInvite: group already at capacity returns FORBIDDEN', async () => {
+  const result = await acceptInvite(
+    {
+      groupRepo: new FakeGroupRepo({
+        groupId: 'g1',
+        inviteExpiresAt: '2030-01-01T00:00:00.000Z',
+        currentMemberCount: 4,
+      }),
+      attempts: new FakeAttempts(),
+      clock: new FixedClock(),
+    },
+    { userId: 'u', ipAddress: '1.2.3.4', code: VALID_CODE },
+  );
+  if (result.ok) throw new Error('expected error');
+  assertEquals(result.error.code, 'FORBIDDEN');
+});
+
+Deno.test('acceptInvite: happy path adds member and records success', async () => {
+  const repo = new FakeGroupRepo({
+    groupId: 'g1',
+    inviteExpiresAt: '2030-01-01T00:00:00.000Z',
+    currentMemberCount: 2,
+  });
+  const attempts = new FakeAttempts();
+  const result = await acceptInvite(
+    { groupRepo: repo, attempts, clock: new FixedClock() },
+    { userId: 'u-new', ipAddress: '1.2.3.4', code: VALID_CODE },
+  );
+  if (!result.ok) throw new Error('expected ok');
+  assertEquals(result.groupId, 'g1');
+  assertEquals(result.memberCount, 3);
+  assertEquals(repo.addMemberCalls.length, 1);
+  assertEquals(attempts.records.length, 1);
+  assertEquals(attempts.records[0]!.success, true);
+});

--- a/supabase/functions/_shared/use-cases/accept-invite.ts
+++ b/supabase/functions/_shared/use-cases/accept-invite.ts
@@ -1,0 +1,100 @@
+import { Api, Group } from '@momentlog/domain/index.ts';
+import type { Clock } from '../ports/driven/clock.ts';
+import type { GroupRepository } from '../ports/driven/group.repository.ts';
+import type { InviteAttemptRepository } from '../ports/driven/invite-attempt.repository.ts';
+
+const ATTEMPT_WINDOW_MS = Math.max(Group.RATE_LIMIT_WINDOW_MS, Group.FAIL_BLOCK_WINDOW_MS);
+
+export interface AcceptInviteInput {
+  readonly userId: string;
+  readonly ipAddress: string;
+  readonly code: string;
+}
+
+export interface AcceptInviteOkOutput {
+  readonly ok: true;
+  readonly groupId: string;
+  readonly groupName: string;
+  readonly memberCount: number;
+}
+
+export type AcceptInviteOutput =
+  | AcceptInviteOkOutput
+  | { readonly ok: false; readonly error: Api.DomainError };
+
+export interface AcceptInviteDeps {
+  readonly groupRepo: GroupRepository;
+  readonly attempts: InviteAttemptRepository;
+  readonly clock: Clock;
+}
+
+export const acceptInvite = async (
+  deps: AcceptInviteDeps,
+  input: AcceptInviteInput,
+): Promise<AcceptInviteOutput> => {
+  const now = deps.clock.now();
+
+  if (!Group.isValidInviteCode(input.code)) {
+    await deps.attempts.record({
+      inviteCode: input.code,
+      ipAddress: input.ipAddress,
+      success: false,
+    });
+    return { ok: false, error: { code: 'INVITE_INVALID' } };
+  }
+
+  const recent = await deps.attempts.recentAttempts(input.ipAddress, ATTEMPT_WINDOW_MS);
+  const rate = Group.evaluateInviteRateLimit({ now, attempts: recent });
+  if (!rate.allowed) {
+    return {
+      ok: false,
+      error: { code: 'INVITE_RATE_LIMITED', retryAfterSec: rate.retryAfterSec },
+    };
+  }
+
+  const resolved = await deps.groupRepo.resolveInviteCode(input.code);
+  if (!resolved) {
+    await deps.attempts.record({
+      inviteCode: input.code,
+      ipAddress: input.ipAddress,
+      success: false,
+    });
+    return { ok: false, error: { code: 'INVITE_INVALID' } };
+  }
+
+  if (Date.parse(resolved.inviteExpiresAt) < now.getTime()) {
+    await deps.attempts.record({
+      inviteCode: input.code,
+      ipAddress: input.ipAddress,
+      success: false,
+    });
+    return { ok: false, error: { code: 'INVITE_INVALID' } };
+  }
+
+  const cap = Group.canAddMember({ currentMemberCount: resolved.currentMemberCount });
+  if (!cap.ok) {
+    await deps.attempts.record({
+      inviteCode: input.code,
+      ipAddress: input.ipAddress,
+      success: false,
+    });
+    return {
+      ok: false,
+      error: { code: 'FORBIDDEN' },
+    };
+  }
+
+  await deps.groupRepo.addMember({ groupId: resolved.groupId, userId: input.userId });
+  await deps.attempts.record({
+    inviteCode: input.code,
+    ipAddress: input.ipAddress,
+    success: true,
+  });
+
+  return {
+    ok: true,
+    groupId: resolved.groupId,
+    groupName: '',
+    memberCount: resolved.currentMemberCount + 1,
+  };
+};

--- a/supabase/functions/_shared/use-cases/create-group.test.ts
+++ b/supabase/functions/_shared/use-cases/create-group.test.ts
@@ -1,0 +1,114 @@
+import { assertEquals } from 'jsr:@std/assert@1';
+import { createGroup } from './create-group.ts';
+import type {
+  GroupCreateResult,
+  GroupRepository,
+  GroupRepositoryCreateInput,
+  InviteCodeResolution,
+} from '../ports/driven/group.repository.ts';
+import type { RandomBytesPort } from '../ports/driven/random-bytes.ts';
+import type { Clock } from '../ports/driven/clock.ts';
+
+class SuccessRepo implements GroupRepository {
+  calls: GroupRepositoryCreateInput[] = [];
+  createGroupWithOwner(input: GroupRepositoryCreateInput): Promise<GroupCreateResult> {
+    this.calls.push(input);
+    return Promise.resolve({
+      ok: true,
+      value: {
+        groupId: 'g-new',
+        inviteCode: input.inviteCode,
+        inviteExpiresAt: input.inviteExpiresAt,
+      },
+    });
+  }
+  resolveInviteCode(): Promise<InviteCodeResolution | null> {
+    return Promise.resolve(null);
+  }
+  addMember(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class ConflictThenSuccessRepo implements GroupRepository {
+  private count = 0;
+  createGroupWithOwner(input: GroupRepositoryCreateInput): Promise<GroupCreateResult> {
+    this.count++;
+    if (this.count < 3) {
+      return Promise.resolve({ ok: false, reason: 'INVITE_CODE_CONFLICT' });
+    }
+    return Promise.resolve({
+      ok: true,
+      value: {
+        groupId: 'g-new',
+        inviteCode: input.inviteCode,
+        inviteExpiresAt: input.inviteExpiresAt,
+      },
+    });
+  }
+  resolveInviteCode(): Promise<InviteCodeResolution | null> {
+    return Promise.resolve(null);
+  }
+  addMember(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class DeterministicRandom implements RandomBytesPort {
+  private counter = 0;
+  bytes(length: number): Uint8Array {
+    const buf = new Uint8Array(length);
+    for (let i = 0; i < length; i++) buf[i] = (this.counter + i) & 0xff;
+    this.counter += length;
+    return buf;
+  }
+}
+
+class FixedClock implements Clock {
+  now(): Date {
+    return new Date('2026-04-24T12:00:00.000Z');
+  }
+}
+
+const validBody = {
+  name: '우리둘',
+  timezone: 'Asia/Seoul',
+  activeHourStart: 9,
+  activeHourEnd: 22,
+};
+
+Deno.test('createGroup: happy path returns groupId and invite code + 24h expiry', async () => {
+  const repo = new SuccessRepo();
+  const result = await createGroup(
+    { repo, random: new DeterministicRandom(), clock: new FixedClock() },
+    { userId: 'u1', body: validBody },
+  );
+  if (!result.ok) throw new Error('expected ok');
+  assertEquals(result.groupId, 'g-new');
+  assertEquals(result.inviteCode.length, 8);
+  assertEquals(result.inviteExpiresAt, '2026-04-25T12:00:00.000Z');
+  assertEquals(repo.calls.length, 1);
+  assertEquals(repo.calls[0]!.name, '우리둘');
+  assertEquals(repo.calls[0]!.ownerId, 'u1');
+});
+
+Deno.test('createGroup: rejects invalid input before touching repo', async () => {
+  const repo = new SuccessRepo();
+  const result = await createGroup(
+    { repo, random: new DeterministicRandom(), clock: new FixedClock() },
+    { userId: 'u1', body: { ...validBody, activeHourStart: 30 } },
+  );
+  if (result.ok) throw new Error('expected error');
+  assertEquals(result.error.code, 'VALIDATION_FAILED');
+  assertEquals(repo.calls.length, 0);
+});
+
+Deno.test('createGroup: retries up to 5 times on invite code conflict', async () => {
+  const repo = new ConflictThenSuccessRepo();
+  const result = await createGroup(
+    { repo, random: new DeterministicRandom(), clock: new FixedClock() },
+    { userId: 'u1', body: validBody },
+  );
+  if (!result.ok) throw new Error('expected ok after retries');
+  assertEquals(result.groupId, 'g-new');
+});

--- a/supabase/functions/_shared/use-cases/create-group.ts
+++ b/supabase/functions/_shared/use-cases/create-group.ts
@@ -1,0 +1,82 @@
+import { Api, Group } from '@momentlog/domain/index.ts';
+import type { Clock } from '../ports/driven/clock.ts';
+import type { GroupRepository } from '../ports/driven/group.repository.ts';
+import type { RandomBytesPort } from '../ports/driven/random-bytes.ts';
+
+const MAX_INVITE_CODE_RETRIES = 5;
+
+export interface CreateGroupInput {
+  readonly userId: string;
+  readonly body: Group.CreateGroupInput;
+}
+
+export interface CreateGroupOkOutput {
+  readonly ok: true;
+  readonly groupId: string;
+  readonly inviteCode: string;
+  readonly inviteExpiresAt: string;
+}
+
+export type CreateGroupOutput =
+  | CreateGroupOkOutput
+  | { readonly ok: false; readonly error: Api.DomainError };
+
+export interface CreateGroupDeps {
+  readonly repo: GroupRepository;
+  readonly random: RandomBytesPort;
+  readonly clock: Clock;
+}
+
+export const createGroup = async (
+  deps: CreateGroupDeps,
+  input: CreateGroupInput,
+): Promise<CreateGroupOutput> => {
+  const validation = Group.validateCreateGroupInput(input.body);
+  if (!validation.ok) {
+    return { ok: false, error: validation.error };
+  }
+  const v = validation.value;
+  const inviteExpiresAt = new Date(deps.clock.now().getTime() + Group.INVITE_TTL_MS).toISOString();
+
+  let lastResult: 'CONFLICT' | 'OK' = 'CONFLICT';
+  let createdGroupId = '';
+  let createdCode = '';
+  for (let attempt = 0; attempt < MAX_INVITE_CODE_RETRIES; attempt++) {
+    const code = Group.generateInviteCode((n) => deps.random.bytes(n));
+    const result = await deps.repo.createGroupWithOwner({
+      name: v.name,
+      ownerId: input.userId,
+      timezone: v.timezone,
+      activeHourStart: v.activeHourStart,
+      activeHourEnd: v.activeHourEnd,
+      inviteCode: code,
+      inviteExpiresAt,
+    });
+    if (result.ok) {
+      lastResult = 'OK';
+      createdGroupId = result.value.groupId;
+      createdCode = result.value.inviteCode;
+      break;
+    }
+    if (result.reason !== 'INVITE_CODE_CONFLICT') {
+      break;
+    }
+  }
+
+  if (lastResult !== 'OK') {
+    return {
+      ok: false,
+      error: {
+        code: 'VALIDATION_FAILED',
+        details: { fields: ['inviteCode'], reason: 'CODE_GENERATION_FAILED' },
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    groupId: createdGroupId,
+    inviteCode: createdCode,
+    inviteExpiresAt,
+  };
+};

--- a/supabase/functions/groups-create/index.ts
+++ b/supabase/functions/groups-create/index.ts
@@ -1,0 +1,189 @@
+import { createClient, type SupabaseClient } from 'jsr:@supabase/supabase-js@2';
+import { Api } from '@momentlog/domain/index.ts';
+import { SystemClock } from '../_shared/adapters/clock/system-clock.ts';
+import { ConsoleLogger } from '../_shared/adapters/logger/console-logger.ts';
+import type {
+  GroupCreateResult,
+  GroupRepository,
+  GroupRepositoryCreateInput,
+  InviteCodeResolution,
+} from '../_shared/ports/driven/group.repository.ts';
+import type { RandomBytesPort } from '../_shared/ports/driven/random-bytes.ts';
+import { createGroup } from '../_shared/use-cases/create-group.ts';
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+const logger = new ConsoleLogger();
+const clock = new SystemClock();
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: CORS_HEADERS });
+  if (req.method !== 'POST') {
+    return json({ error: 'METHOD_NOT_ALLOWED', message: 'POST only', details: {} }, 405);
+  }
+
+  const authHeader = req.headers.get('Authorization') ?? '';
+  if (!authHeader.toLowerCase().startsWith('bearer ')) {
+    return errorResponse({ code: 'UNAUTHORIZED' });
+  }
+
+  const supabaseUrl = must('SUPABASE_URL');
+  const anonKey = must('SUPABASE_ANON_KEY');
+  const serviceKey = must('SUPABASE_SERVICE_ROLE_KEY');
+
+  const userClient = createClient(supabaseUrl, anonKey, {
+    global: { headers: { Authorization: authHeader } },
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const {
+    data: { user },
+    error: authError,
+  } = await userClient.auth.getUser();
+  if (authError || !user) {
+    return errorResponse({ code: 'UNAUTHORIZED' });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse({ code: 'VALIDATION_FAILED', details: { fields: ['body'] } });
+  }
+  if (typeof body !== 'object' || body === null) {
+    return errorResponse({ code: 'VALIDATION_FAILED', details: { fields: ['body'] } });
+  }
+
+  const adminClient = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const result = await createGroup(
+    {
+      repo: new SupabaseGroupRepository(adminClient),
+      random: new WebCryptoRandomBytes(),
+      clock,
+    },
+    { userId: user.id, body: body as Parameters<typeof createGroup>[1]['body'] },
+  );
+
+  if (!result.ok) {
+    logger.info('groups-create rejected', { userId: user.id, code: result.error.code });
+    return errorResponse(result.error);
+  }
+
+  logger.info('groups-create ok', { userId: user.id, groupId: result.groupId });
+  return json(
+    {
+      groupId: result.groupId,
+      inviteCode: result.inviteCode,
+      inviteExpiresAt: result.inviteExpiresAt,
+    },
+    201,
+  );
+});
+
+class WebCryptoRandomBytes implements RandomBytesPort {
+  bytes(length: number): Uint8Array {
+    const buf = new Uint8Array(length);
+    crypto.getRandomValues(buf);
+    return buf;
+  }
+}
+
+class SupabaseGroupRepository implements GroupRepository {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async createGroupWithOwner(input: GroupRepositoryCreateInput): Promise<GroupCreateResult> {
+    const { data: groupRow, error: groupErr } = await this.client
+      .from('groups')
+      .insert({
+        name: input.name,
+        owner_id: input.ownerId,
+        timezone: input.timezone,
+        active_hour_start: input.activeHourStart,
+        active_hour_end: input.activeHourEnd,
+        invite_code: input.inviteCode,
+        invite_expires_at: input.inviteExpiresAt,
+      })
+      .select('id, invite_code, invite_expires_at')
+      .single();
+
+    if (groupErr) {
+      if (groupErr.code === '23505') {
+        return { ok: false, reason: 'INVITE_CODE_CONFLICT' };
+      }
+      throw new Error(`createGroup failed: ${groupErr.message}`);
+    }
+    if (!groupRow) {
+      throw new Error('createGroup returned no row');
+    }
+
+    const { error: memberErr } = await this.client.from('group_members').insert({
+      group_id: groupRow.id,
+      user_id: input.ownerId,
+      role: 'owner',
+    });
+    if (memberErr) {
+      throw new Error(`addOwnerMember failed: ${memberErr.message}`);
+    }
+
+    return {
+      ok: true,
+      value: {
+        groupId: String(groupRow.id),
+        inviteCode: String(groupRow.invite_code),
+        inviteExpiresAt: String(groupRow.invite_expires_at),
+      },
+    };
+  }
+
+  async resolveInviteCode(code: string): Promise<InviteCodeResolution | null> {
+    const { data, error } = await this.client
+      .from('groups')
+      .select('id, invite_expires_at, group_members(count)')
+      .eq('invite_code', code)
+      .maybeSingle();
+    if (error) throw new Error(`resolveInviteCode failed: ${error.message}`);
+    if (!data) return null;
+    const membersField = data.group_members as unknown as ReadonlyArray<{ count: number }> | null;
+    const currentMemberCount = membersField?.[0]?.count ?? 0;
+    return {
+      groupId: String(data.id),
+      inviteExpiresAt: String(data.invite_expires_at),
+      currentMemberCount,
+    };
+  }
+
+  async addMember(input: { groupId: string; userId: string }): Promise<void> {
+    const { error } = await this.client.from('group_members').insert({
+      group_id: input.groupId,
+      user_id: input.userId,
+      role: 'member',
+    });
+    if (error) {
+      throw new Error(`addMember failed: ${error.message}`);
+    }
+  }
+}
+
+function errorResponse(e: Api.DomainError): Response {
+  const { status, body } = Api.toErrorResponse(e);
+  return json(body, status);
+}
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+  });
+}
+
+function must(key: string): string {
+  const v = Deno.env.get(key);
+  if (!v || v.trim() === '') throw new Error(`Missing required env var: ${key}`);
+  return v;
+}

--- a/supabase/functions/invites-accept/index.ts
+++ b/supabase/functions/invites-accept/index.ts
@@ -1,0 +1,178 @@
+import { createClient, type SupabaseClient } from 'jsr:@supabase/supabase-js@2';
+import { Api } from '@momentlog/domain/index.ts';
+import type { InviteAttempt } from '@momentlog/domain/group/index.ts';
+import { SystemClock } from '../_shared/adapters/clock/system-clock.ts';
+import { ConsoleLogger } from '../_shared/adapters/logger/console-logger.ts';
+import type {
+  InviteAttemptRepository,
+  RecordAttemptInput,
+} from '../_shared/ports/driven/invite-attempt.repository.ts';
+import type {
+  GroupCreateResult,
+  GroupRepository,
+  GroupRepositoryCreateInput,
+  InviteCodeResolution,
+} from '../_shared/ports/driven/group.repository.ts';
+import { acceptInvite } from '../_shared/use-cases/accept-invite.ts';
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+const logger = new ConsoleLogger();
+const clock = new SystemClock();
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: CORS_HEADERS });
+  if (req.method !== 'POST') {
+    return json({ error: 'METHOD_NOT_ALLOWED', message: 'POST only', details: {} }, 405);
+  }
+
+  const authHeader = req.headers.get('Authorization') ?? '';
+  if (!authHeader.toLowerCase().startsWith('bearer ')) {
+    return errorResponse({ code: 'UNAUTHORIZED' });
+  }
+
+  const supabaseUrl = must('SUPABASE_URL');
+  const anonKey = must('SUPABASE_ANON_KEY');
+  const serviceKey = must('SUPABASE_SERVICE_ROLE_KEY');
+
+  const userClient = createClient(supabaseUrl, anonKey, {
+    global: { headers: { Authorization: authHeader } },
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const {
+    data: { user },
+    error: authError,
+  } = await userClient.auth.getUser();
+  if (authError || !user) {
+    return errorResponse({ code: 'UNAUTHORIZED' });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse({ code: 'VALIDATION_FAILED', details: { fields: ['body'] } });
+  }
+  const code =
+    typeof body === 'object' && body !== null ? ((body as { code?: unknown }).code ?? '') : '';
+
+  const ipAddress =
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    req.headers.get('x-real-ip') ??
+    'unknown';
+
+  const adminClient = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const result = await acceptInvite(
+    {
+      groupRepo: new SupabaseGroupRepository(adminClient),
+      attempts: new SupabaseInviteAttempts(adminClient),
+      clock,
+    },
+    {
+      userId: user.id,
+      ipAddress,
+      code: String(code),
+    },
+  );
+
+  if (!result.ok) {
+    logger.info('invites-accept rejected', { userId: user.id, code: result.error.code });
+    return errorResponse(result.error);
+  }
+
+  logger.info('invites-accept ok', { userId: user.id, groupId: result.groupId });
+  return json(
+    {
+      groupId: result.groupId,
+      groupName: result.groupName,
+      memberCount: result.memberCount,
+    },
+    200,
+  );
+});
+
+class SupabaseInviteAttempts implements InviteAttemptRepository {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async recentAttempts(ipAddress: string, sinceMs: number): Promise<readonly InviteAttempt[]> {
+    const since = new Date(Date.now() - sinceMs).toISOString();
+    const { data, error } = await this.client
+      .from('invite_attempts')
+      .select('attempted_at, success')
+      .eq('ip_address', ipAddress)
+      .gte('attempted_at', since);
+    if (error) throw new Error(`recentAttempts failed: ${error.message}`);
+    return (data ?? []).map((r: { attempted_at: string; success: boolean }) => ({
+      attemptedAt: r.attempted_at,
+      success: r.success,
+    }));
+  }
+
+  async record(input: RecordAttemptInput): Promise<void> {
+    const { error } = await this.client.from('invite_attempts').insert({
+      invite_code: input.inviteCode,
+      ip_address: input.ipAddress,
+      success: input.success,
+    });
+    if (error) throw new Error(`record invite attempt failed: ${error.message}`);
+  }
+}
+
+class SupabaseGroupRepository implements GroupRepository {
+  constructor(private readonly client: SupabaseClient) {}
+
+  createGroupWithOwner(_: GroupRepositoryCreateInput): Promise<GroupCreateResult> {
+    return Promise.reject(new Error('not implemented in invites-accept scope'));
+  }
+
+  async resolveInviteCode(code: string): Promise<InviteCodeResolution | null> {
+    const { data, error } = await this.client
+      .from('groups')
+      .select('id, invite_expires_at, group_members(count)')
+      .eq('invite_code', code)
+      .maybeSingle();
+    if (error) throw new Error(`resolveInviteCode failed: ${error.message}`);
+    if (!data) return null;
+    const membersField = data.group_members as unknown as ReadonlyArray<{ count: number }> | null;
+    const currentMemberCount = membersField?.[0]?.count ?? 0;
+    return {
+      groupId: String(data.id),
+      inviteExpiresAt: String(data.invite_expires_at),
+      currentMemberCount,
+    };
+  }
+
+  async addMember(input: { groupId: string; userId: string }): Promise<void> {
+    const { error } = await this.client.from('group_members').insert({
+      group_id: input.groupId,
+      user_id: input.userId,
+      role: 'member',
+    });
+    if (error) throw new Error(`addMember failed: ${error.message}`);
+  }
+}
+
+function errorResponse(e: Api.DomainError): Response {
+  const { status, body } = Api.toErrorResponse(e);
+  return json(body, status);
+}
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+  });
+}
+
+function must(key: string): string {
+  const v = Deno.env.get(key);
+  if (!v || v.trim() === '') throw new Error(`Missing required env var: ${key}`);
+  return v;
+}


### PR DESCRIPTION
## 요약

플랜 Wave 3 의 서버측 구현 (Tasks 13, 14 — 이슈 #14, #15). 그룹 생성과 초대 수락에 대응하는 두 Edge Function 을 Hexagonal 구조로 구현합니다. UI 부분(task 15 카메라, task 17 그룹 목록)은 RN 실제 설치 사이클이 필요해 별도 후속 PR 로 분리합니다.

## 변경 사항

### Domain 순수 로직 (`packages/domain/src/group/`)
- **`invite-code.ts`**: 8자 영숫자 코드, 혼동문자(`0`,`O`,`1`,`I`,`L`) 제외, 24h TTL. `generateInviteCode(randomBytes)` 는 주입된 바이트 소스로 **결정론적** — 테스트에서는 고정 시퀀스, production 에서는 `crypto.getRandomValues`.
- **`create-validation.ts`**: 그룹 생성 입력 검증 (이름 1~40자, IANA timezone, activeHour 0~23, start<end). `VALIDATION_FAILED.details.fields` 에 모든 위반 필드를 누적.
- **`invite-rate-limit.ts`**: PRD §8.8 기준 IP 단위 rate limit. 시간당 **>10회** `RATE_LIMITED_HOURLY`, 15분 내 **≥5회 실패** `FAILURE_BLOCK`. `retryAfterSec` 까지 반환.
- **`membership-limit.ts`**: `MAX_GROUP_MEMBERS=4`, `canAddMember({ currentMemberCount })` 순수 체크.

### Driven Ports (`supabase/functions/_shared/ports/driven/`)
- **`group.repository.ts`**: `createGroupWithOwner` / `resolveInviteCode` / `addMember`. `createGroupWithOwner` 는 unique-conflict 를 `INVITE_CODE_CONFLICT` reason 으로 **도메인 타입**으로 번역해 use case 가 retry 가능.
- **`invite-attempt.repository.ts`**: `recentAttempts(ip, sinceMs)` + `record(input)`.
- **`random-bytes.ts`**: `Uint8Array` 반환 인터페이스.

### Use Cases (`supabase/functions/_shared/use-cases/`)
- **`create-group.ts`**: 입력 검증 → 초대코드 생성 → 그룹 + owner 멤버 INSERT. `INVITE_CODE_CONFLICT` 발생 시 최대 5회 재생성. 성공 시 `groupId`/`inviteCode`/`inviteExpiresAt` 반환.
- **`accept-invite.ts`**: 코드 형식 검증 → 최근 시도 조회 → rate limit 평가 → 코드 해석 → 만료 확인 → 정원 확인 → `addMember`. **모든 경로에서 attempt 를 기록**해 rate limit 이 정확히 작동.
- `Deno.test` 단위 테스트: `FakeGroupRepo` / `FakeAttempts` / `DeterministicRandom` / `FixedClock` 로 happy + 주요 에러 경로 커버. `jest.mock('@supabase/supabase-js')` 사용 없음 (CODING_STANDARDS §13.1 준수).

### Primary Adapters (Edge Functions)
- **`supabase/functions/groups-create/index.ts`**: `Deno.serve` + CORS, `Authorization: Bearer` JWT → `auth.getUser()` → service_role 클라이언트로 use case 실행. 201 응답.
- **`supabase/functions/invites-accept/index.ts`**: IP 를 `x-forwarded-for` → `x-real-ip` 순으로 추출. 200 응답.
- 두 Edge Function 모두 `Api.toErrorResponse` 단일 매핑 경로로 `DomainError` → HTTP 응답 (CODING_STANDARDS §6.3 DRY).

## 원칙 준수

- ARCHITECTURE.md §P-1: use case 는 port 만 의존. Supabase SDK import 없음.
- ARCHITECTURE.md §P-2: Hexagonal — port 와 adapter 분리. adapter 가 `@supabase/*` 유일한 사용처.
- CODING_STANDARDS §3.3 Idempotency: `createGroupWithOwner` 의 unique-conflict 재시도 로직으로 멱등성 확보.
- CODING_STANDARDS §7.2 Rate Limit: service_role 접근 정책, `invite_attempts` 기반 rate limit 전략을 domain 순수 함수로 격리.
- 플랜 GR-13 TDD: 각 도메인 함수를 RED → GREEN 순서로 구현, 테스트가 boundary (>10, 10 정확, 15min 정확, 4+1 멤버 등)를 모두 cover.

## 검증

- **pnpm --filter @momentlog/domain test:coverage**: **157/157 통과** (이전 110 + 신규 47), 커버리지 **100%** 유지.
- **pnpm typecheck**: 3 workspace 모두 통과.
- **pnpm lint**: 에러 0. `packages/domain` 의 `no-restricted-imports` 통과 (use case 가 port 만 import).
- **pnpm format:check**: 통과.
- Deno unit test 는 `deno test --allow-all` 로 로컬에서 실행 가능 (CI 통합은 별도 후속).

## 체크리스트

- [x] 제목이 Conventional Commits 형식 (`feat(edge): wave-3 서버측 — ...`)
- [x] 제목·본문 한글
- [x] 원자적 범위 (Wave 3 서버측 그룹/초대 플로우 한 가지 논리 단위)
- [x] `pnpm typecheck`/`lint`/`format:check`/`test:coverage` 모두 통과
- [x] `any`, `@ts-ignore`, non-null `!` 없음 (non-null 이 필요한 곳은 narrowing 사용)
- [x] 프로덕션 경로에 `console.log` / `console.error` 없음 (`ConsoleLogger` port)
- [x] PII / 시크릿 없음 (service_role key 응답 노출 없음)
- [x] 금지된 내부 문서 포함 없음
- [x] Closes #14 #15

## 관련

- 플랜: `.sisyphus/plans/momentlog-mvp.md` Wave 3 Tasks 13, 14
- 이슈: #14 (`[task-13] 그룹 생성 API + UI`), #15 (`[task-14] 초대 수락 API + UI + Rate Limit`)
- UI 부분 (task 13/14 의 `app/(tabs)/groups/index.tsx`, `app/(auth)/onboarding.tsx`) 은 RN 앱 부트스트랩 이후 별도 PR.